### PR TITLE
Issue #173 - Display Price visibility issue in DrillDown View

### DIFF
--- a/Website/DesktopModules/Hotcakes/Core/Models/Json/SingleProductJsonModel.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Models/Json/SingleProductJsonModel.cs
@@ -45,7 +45,7 @@ namespace Hotcakes.Modules.Core.Models.Json
             Bvin = product.Bvin;
 
             var up = app.PriceProduct(product, app.CurrentCustomer, null, app.CurrentlyActiveSales);
-            UserPrice = up.DisplayPrice();
+            UserPrice = up.DisplayPrice(true,false);
         }
 
         public string ProductLink { get; set; }


### PR DESCRIPTION
1- Add `category viewer` module to a page
2- set drill Down as a view 
3- display price of products does not include currency symbol and other adjustment