### PR TITLE
Issue #189 - Assign membership only after successful payment

### DIFF
--- a/Libraries/Hotcakes.Commerce.Dnn/Workflow/DnnWorkflowFactory.cs
+++ b/Libraries/Hotcakes.Commerce.Dnn/Workflow/DnnWorkflowFactory.cs
@@ -62,10 +62,23 @@ namespace Hotcakes.Commerce.Dnn.Workflow
                 new UpdateOrder(),
                 new DnnMakePlacedOrder(),
                 new WorkflowNote("Finished Process Order Workflow"),
-                new UpdateOrder(),
+                new UpdateOrder()
+            };
+        }
 
-                // Added to handle "membership" products
-                new MembershipTask()
+        protected override Task[] LoadProcessNewOrderAfterPaymentsTasks()
+        {
+            return new Task[]
+            {
+                new WorkflowNote("Starting Order After Payment Workflow"),
+                new UpdateOrder(),
+                new LocalFraudCheck(),
+                new MarkCompletedWhenShippedAndPaid(),
+                new EmailOrder("Customer"),
+                new EmailOrder("Admin"),
+                new MembershipTask(),
+                new WorkflowNote("Finished Order After Payment Workflow"),
+                new UpdateOrder()
             };
         }
     }


### PR DESCRIPTION
MembershipTask() has been moved from LoadProcessNewOrderTasks() to LoadProcessNewOrderAfterPaymentTasks() to avoid assigning user accounts to failed payment orders.