### PR TITLE
Paypal Express Hold Authorization failure still allows order to process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@
 *.dotCover
 *.ldf
 MSBuildLog.txt
-_[Bb]uild/
 
 # git merge artifacts
 *.orig
@@ -83,7 +82,7 @@ UpgradeLog*.XML
 
 # Ignore artifacts from deployed/installed site
 
-_[Ii]nstall/
+_[Ii]nstall
 
 *.zip.manifest
 
@@ -103,11 +102,14 @@ Thumbs.db
 # Folder config file
 Desktop.ini
 
+[Ww]ebsite/[Aa]pp_[Cc]ode
+[Ww]ebsite/[Aa]pp_[Dd]ata
+![Ww]ebsite/[Aa]pp_[Dd]ata/[Pp]lace[Hh]older.txt
 [Ww]ebsite/[Aa]pp_[Dd]ata
 [Ww]ebsite/[Bb]in
 [Ww]ebsite/[Bb]in/[Hh]otcakes.*
 [Ww]ebsite/[Dd]esktop[Mm]odules/[Hh]otcakes/[Bb]in
-[Ww]ebsite/[Ii]nstall/[Tt]emp/
+[Ww]bsite/[Ii]nstall/[Tt]emp/
 [Ww]ebsite/[Ii]nstall/*/*.zip
 [Ww]ebsite/[Ii]nstall/*/*.resources
 [Ww]ebsite/[Ii]nstall/[Cc]leanup
@@ -122,3 +124,10 @@ Desktop.ini
 [Ww]ebsite/[Pp]ortals/_default/[Ss]kins/[Xx]cillion/
 [Ww]ebsite/[Pp]ortals/_default/[Cc]ontainers/[Xx]cillion/
 [Ww]ebsite/[Pp]ortals/**/Cache
+/Website/DesktopModules/Hotcakes/Hotcakes.Modules.csproj.bak
+/Website/web.config.bak
+/Website/Hotcakes.Views.csproj.bak
+/Website/DesktopModules/Hotcakes/Core/Controllers/CartController.cs.bak
+/Website/DesktopModules/Hotcakes/MiniCart/MiniCartView.ascx.cs.bak
+/Website/Portals/_default/HotcakesViews/_default/Scripts/App_LocalResources/ScriptResources.resx.bak
+/Website/Portals/_default/HotcakesViews/_default/Views/Cart/MiniCart.cshtml.bak

--- a/Libraries/Hotcakes.Commerce.Dnn/Web/HotcakesModuleBase.cs
+++ b/Libraries/Hotcakes.Commerce.Dnn/Web/HotcakesModuleBase.cs
@@ -182,10 +182,10 @@ namespace Hotcakes.Commerce.Dnn.Web
                 var analyticsScript = string.Empty;
                 if (HccApp.CurrentStore.Settings.Analytics.UseGoogleEcommerce)
                 {
-                    analyticsScript = " ga('require', 'ecommerce'); ";
+                    analyticsScript = "try { ga('require', 'ecommerce'); }\n catch(err) {}";
                 }
 
-                var scriptResource = string.Format(" {1} var hcc = hcc || {{}}; hcc.l10n = {0};", json, analyticsScript);
+                var scriptResource = string.Format(" {1}\n var hcc = hcc || {{}};\n hcc.l10n = {0};\n", json, analyticsScript);
                 ScriptManager.RegisterClientScriptBlock(this, typeof (HotcakesModuleBase), "ScriptResources",
                     scriptResource, true);
 

--- a/Libraries/Hotcakes.Commerce/Data/EF/HccDbContext.Designer.cs
+++ b/Libraries/Hotcakes.Commerce/Data/EF/HccDbContext.Designer.cs
@@ -1,4 +1,4 @@
-﻿// T4 code generation is enabled for model 'D:\Projects\Hotcakes\HCC\Branches\2.xxOpenSource\Libraries\Hotcakes.Commerce\Data\EF\HccDbContext.edmx'. 
+﻿// T4 code generation is enabled for model 'C:\Users\swilk\Source\Repos\hotcakes-commerce-core\Libraries\Hotcakes.Commerce\Data\EF\HccDbContext.edmx'. 
 // To enable legacy code generation, change the value of the 'Code Generation Strategy' designer
 // property to 'Legacy ObjectContext'. This property is available in the Properties Window when the model
 // is open in the designer.

--- a/Libraries/Hotcakes.Commerce/Data/EF/HccDbContext.edmx
+++ b/Libraries/Hotcakes.Commerce/Data/EF/HccDbContext.edmx
@@ -1380,6 +1380,8 @@
           <Property Name="Settings" Type="ntext" Nullable="false" />
           <Property Name="VisibilityMode" Type="int" Nullable="false" />
           <Property Name="VisibilityAmount" Type="decimal" Scale="2" />
+          <Property Name="VisibilityModeSecondary" Type="int" Nullable="false" />
+          <Property Name="VisibilityAmountSecondary" Type="decimal" Scale="2" />
           <Property Name="SortOrder" Type="int" Nullable="false" />
         </EntityType>
         <EntityType Name="hcc_ShippingMethodTranslations">
@@ -3478,6 +3480,8 @@
           <NavigationProperty Name="hcc_ShippingMethodTranslations" Relationship="EfModels.FK_hcc_ShippingMethodTranslations_hcc_ShippingMethodTranslations" FromRole="hcc_ShippingMethod" ToRole="hcc_ShippingMethodTranslations" />
           <Property Type="Int32" Name="VisibilityMode" Nullable="false" />
           <Property Type="Decimal" Name="VisibilityAmount" Precision="18" Scale="2" />
+          <Property Type="Int32" Name="VisibilityModeSecondary" Nullable="false" />
+          <Property Type="Decimal" Name="VisibilityAmountSecondary" Precision="18" Scale="2" />
           <Property Type="Int32" Name="SortOrder" Nullable="false" />
         </EntityType>
         <EntityType Name="hcc_User">
@@ -5688,6 +5692,8 @@
                 <ScalarProperty Name="SortOrder" ColumnName="SortOrder" />
                 <ScalarProperty Name="VisibilityAmount" ColumnName="VisibilityAmount" />
                 <ScalarProperty Name="VisibilityMode" ColumnName="VisibilityMode" />
+                <ScalarProperty Name="VisibilityAmountSecondary" ColumnName="VisibilityAmountSecondary" />
+                <ScalarProperty Name="VisibilityModeSecondary" ColumnName="VisibilityModeSecondary" />
                 <ScalarProperty Name="Settings" ColumnName="Settings" />
                 <ScalarProperty Name="ZoneId" ColumnName="ZoneId" />
                 <ScalarProperty Name="StoreId" ColumnName="StoreId" />

--- a/Libraries/Hotcakes.Commerce/Data/EF/hcc_ShippingMethod.cs
+++ b/Libraries/Hotcakes.Commerce/Data/EF/hcc_ShippingMethod.cs
@@ -29,6 +29,8 @@ namespace Hotcakes.Commerce.Data.EF
         public string Settings { get; set; }
         public int VisibilityMode { get; set; }
         public Nullable<decimal> VisibilityAmount { get; set; }
+        public int VisibilityModeSecondary { get; set; }
+        public Nullable<decimal> VisibilityAmountSecondary { get; set; }
         public int SortOrder { get; set; }
     
         public virtual ICollection<hcc_ShippingMethodTranslation> hcc_ShippingMethodTranslations { get; set; }

--- a/Libraries/Hotcakes.Commerce/Orders/OrderPaymentManager.cs
+++ b/Libraries/Hotcakes.Commerce/Orders/OrderPaymentManager.cs
@@ -1034,7 +1034,8 @@ namespace Hotcakes.Commerce.Orders
 
         public bool PayPalExpressHold(OrderTransaction infoTransaction, decimal amount)
         {
-            if (infoTransaction == null) return false;
+            var txnSuccess = false;
+            if (infoTransaction == null) return txnSuccess;
 
             var t = CreateEmptyTransaction();
             t.Card = infoTransaction.CreditCard;
@@ -1053,12 +1054,14 @@ namespace Hotcakes.Commerce.Orders
             var processor = new PaypalExpress();
             if (processor != null)
             {
-                processor.Authorize(t, _app);
+                var paymentAuthorized = processor.Authorize(t, _app);
                 ot = new OrderTransaction(t);
+                ot.Success = ot.Success && paymentAuthorized;
                 ot.LinkedToTransaction = infoTransaction.IdAsString;
             }
 
-            return svc.AddPaymentTransactionToOrder(o, ot);
+            txnSuccess = ot.Success && svc.AddPaymentTransactionToOrder(o, ot);
+            return txnSuccess;
         }
 
         public bool PayPalExpressCapture(string holdTransactionId, decimal amount)

--- a/Libraries/Hotcakes.Commerce/Orders/OrderService.cs
+++ b/Libraries/Hotcakes.Commerce/Orders/OrderService.cs
@@ -252,23 +252,18 @@ namespace Hotcakes.Commerce.Orders
                                 subtotal = true;
                             }
                         }
-                        else if (method.VisibilityMode == ShippingVisibilityMode.SubtotalAmount)
+                        else
                         {
-                            if (method.VisibilityAmount.HasValue &&
-                                order.TotalOrderAfterDiscounts > method.VisibilityAmount.Value)
+                            if (EvaluateVisibilityWithAmount(method.VisibilityMode, method.VisibilityAmount, order))
                             {
-                                subtotal = true;
-                            }
-                            else
-                            {
-                                ratesSort.Remove(rate);
-                            }
-                        }
-                        else if (method.VisibilityMode == ShippingVisibilityMode.TotalWeight)
-                        {
-                            if (method.VisibilityAmount.HasValue && order.TotalWeight > method.VisibilityAmount.Value)
-                            {
-                                subtotal = true;
+                                if (EvaluateVisibilityWithAmount(method.VisibilityModeSecondary, method.VisibilityAmountSecondary, order))
+                                {
+                                    subtotal = true;
+                                }
+                                else
+                                {
+                                    ratesSort.Remove(rate);
+                                }
                             }
                             else
                             {
@@ -278,6 +273,37 @@ namespace Hotcakes.Commerce.Orders
                     }
                 }
             }
+        }
+
+        private bool EvaluateVisibilityWithAmount(ShippingVisibilityMode visibilityMode, decimal? visibilityAmount, Order order)
+        {
+            var meetsCriteria = false;
+            switch (visibilityMode)
+            {
+                case ShippingVisibilityMode.SubtotalAmount:
+                    if (visibilityAmount.HasValue && order.TotalOrderAfterDiscounts > visibilityAmount.Value)
+                    {
+                        meetsCriteria = true;
+                    }
+                    break;
+                case ShippingVisibilityMode.TotalWeight:
+                    if (visibilityAmount.HasValue && order.TotalWeight > visibilityAmount.Value)
+                    {
+                        meetsCriteria = true;
+                    }
+                    break;
+                case ShippingVisibilityMode.TotalWeightLessThan:
+                    if (visibilityAmount.HasValue && order.TotalWeight < visibilityAmount.Value)
+                    {
+                        meetsCriteria = true;
+                    }
+                    break;
+                default:
+                    meetsCriteria = true;
+                    break;
+            }
+
+            return meetsCriteria;
         }
 
         public SortableCollection<ShippingRateDisplay> FindAvailableShippingRates(Order order)

--- a/Libraries/Hotcakes.Commerce/Shipping/ShippingMethod.cs
+++ b/Libraries/Hotcakes.Commerce/Shipping/ShippingMethod.cs
@@ -115,6 +115,10 @@ namespace Hotcakes.Commerce.Shipping
 
         public decimal? VisibilityAmount { get; set; }
 
+        public ShippingVisibilityMode VisibilityModeSecondary { get; set; }
+
+        public decimal? VisibilityAmountSecondary { get; set; }
+
         public int SortOrder { get; set; }
 
         private IShipment ConvertGroupsToShipments(List<ShippingGroup> groups)

--- a/Libraries/Hotcakes.Commerce/Shipping/ShippingMethodRepository.cs
+++ b/Libraries/Hotcakes.Commerce/Shipping/ShippingMethodRepository.cs
@@ -77,6 +77,8 @@ namespace Hotcakes.Commerce.Shipping
             model.ZoneId = data.ZoneId;
             model.VisibilityMode = (ShippingVisibilityMode) data.VisibilityMode;
             model.VisibilityAmount = data.VisibilityAmount;
+            model.VisibilityModeSecondary = (ShippingVisibilityMode) data.VisibilityModeSecondary;
+            model.VisibilityAmountSecondary = data.VisibilityAmountSecondary;
             model.SortOrder = data.SortOrder;
         }
 
@@ -98,6 +100,8 @@ namespace Hotcakes.Commerce.Shipping
             data.Item.ZoneId = model.ZoneId;
             data.Item.VisibilityMode = (int) model.VisibilityMode;
             data.Item.VisibilityAmount = model.VisibilityAmount;
+            data.Item.VisibilityModeSecondary = (int)model.VisibilityModeSecondary;
+            data.Item.VisibilityAmountSecondary = model.VisibilityAmountSecondary;
             data.Item.SortOrder = model.SortOrder;
         }
 

--- a/Libraries/Hotcakes.Commerce/Shipping/ShippingVisibilityMode.cs
+++ b/Libraries/Hotcakes.Commerce/Shipping/ShippingVisibilityMode.cs
@@ -54,6 +54,12 @@ namespace Hotcakes.Commerce.Shipping
         ///     The total weight of all line items must be greater than the specified total in order to be included in the shipping
         ///     calculation and rate retrieval methods.
         /// </summary>
-        TotalWeight = 4
+        TotalWeight = 4,
+
+        /// <summary>
+        ///     The total weight of all line items must be less than the specified total in order to be included in the shipping
+        ///     calculation and rate retrieval methods.
+        /// </summary>
+        TotalWeightLessThan = 5
     }
 }

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Configuration/App_LocalResources/Shipping_Methods.aspx.resx
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Configuration/App_LocalResources/Shipping_Methods.aspx.resx
@@ -180,4 +180,22 @@
   <data name="TotalWeightItem.Text" xml:space="preserve">
     <value>Total Weight</value>
   </data>
+  <data name="SubtotalAmountSecondary.Text" xml:space="preserve">
+    <value> AND Subtotal &gt; {0}</value>
+  </data>
+  <data name="TotalWeightLessThan.Text" xml:space="preserve">
+    <value>Total Weight &lt; {0}</value>
+  </data>
+  <data name="TotalWeightLessThanSecondary.Text" xml:space="preserve">
+    <value> AND Total Weight &lt; {0}</value>
+  </data>
+  <data name="TotalWeightSecondary.Text" xml:space="preserve">
+    <value> AND Total Weight &gt; {0}</value>
+  </data>
+  <data name="ShowWhenItemSecondary.Text" xml:space="preserve">
+    <value>Show When (Secondary)</value>
+  </data>
+  <data name="SubtotalAmountItemSecondary.Text" xml:space="preserve">
+    <value>Subtotal Amount (Secondary)</value>
+  </data>
 </root>

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Configuration/Shipping_Methods.aspx
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Configuration/Shipping_Methods.aspx
@@ -84,7 +84,7 @@
             </asp:GridView>
             <asp:Panel ID="pnlEditVisibility" runat="server" Visible="false">
                 <div id="hcVisibilityDialog" class="dnnClear">
-                    <div style="height: 300px">
+                    <div style="min-height: 300px">
                         <div class="hcForm">
                             <div class="hcFormItem">
                                 <label class="hcLabel"><%=Localization.GetString("MethodName") %></label>
@@ -104,6 +104,22 @@
                                 <asp:CompareValidator ValidationGroup="SaveRule" ID="cvAmount" ControlToValidate="txtSubtotal"
                                     Operator="DataTypeCheck" Type="Currency" CssClass="hcFormError" runat="server" />
                             </div>
+                            <asp:Panel ID="pnlSecondDisplayRule" runat="server" Visible="false">
+                                <div class="hcFormItem">
+                                    <label class="hcLabel"><%=Localization.GetString("ShowWhenItemSecondary") %></label>
+                                    <asp:DropDownList ID="ddlTypes2" runat="server" />
+                                </div>
+                                <div class="hcFormItem hcSubtotalAmount">
+                                    <label class="hcLabel hc-label-amount2"><%=Localization.GetString("SubtotalAmountItemSecondary") %></label>
+                                    <asp:TextBox CssClass="hc-textbox-amount2" ID="txtSubtotal2" runat="server" />
+                                    <asp:RequiredFieldValidator ValidationGroup="SaveRule" ID="rfvAmount2" ControlToValidate="txtSubtotal2" CssClass="hcFormError"
+                                                                runat="server" />
+                                    <asp:CompareValidator ValidationGroup="SaveRule" ID="cvAmountSb2" ControlToValidate="txtSubtotal2"
+                                                          Operator="GreaterThanEqual" ValueToCompare="0" Type="Currency" CssClass="hcFormError" runat="server" />
+                                    <asp:CompareValidator ValidationGroup="SaveRule" ID="cvAmountSb" ControlToValidate="txtSubtotal2"
+                                                          Operator="DataTypeCheck" Type="Currency" CssClass="hcFormError" runat="server" />
+                                </div>
+                            </asp:Panel>
                         </div>
                     </div>                 
                     <div class="hcActionsRight">

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Configuration/Shipping_Methods.aspx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Configuration/Shipping_Methods.aspx.cs
@@ -92,6 +92,10 @@ namespace Hotcakes.Modules.Core.Admin.Configuration
             cvAmount.Text = Localization.GetString("Decimal");
             cvAmount2.Text = Localization.GetString("GreaterThan");
             rfvAmount.Text = Localization.GetString("Required");
+
+            cvAmountSb.Text = Localization.GetString("Decimal");
+            cvAmountSb2.Text = Localization.GetString("GreaterThan");
+            rfvAmount2.Text = Localization.GetString("Required");
         }
 
         #endregion
@@ -105,50 +109,50 @@ namespace Hotcakes.Modules.Core.Admin.Configuration
                 var labelSubtotal = Localization.GetString("SubtotalAmountItem");
                 var labelWeight = Localization.GetString("TotalWeightItem");
 
-
                 var script = @"hcShowDialog(); 
-                            $('#" + ddlTypes.ClientID + @"')
-                                  .change(function () { 
-                                            if( $(this).val() > 2 )
-                                            { 
-                                                $('.hcSubtotalAmount').show();
+                    $('#" + ddlTypes.ClientID + @"')
+                        .change(function () { 
+                            if( $(this).val() > 2 )
+                            { 
+                                $('.hcSubtotalAmount').show();
+                                $('#" + pnlSecondDisplayRule.ClientID + @"').show();
 
-                                                if( $(this).val() == 4 )
-                                                {
-                                                    $('.hc-label-amount').html('" + labelWeight + @"');          
-                                                }
-                                                else if( $(this).val() == 3 )
-                                                {
-                                                    $('.hc-label-amount').html('" + labelSubtotal +
-                             @"');                         
-                                                }
-                                            }
-                                            else
-                                            {
-                                                $('.hcSubtotalAmount').hide();
-                                                $('.hc-textbox-amount').val('0'); 
-                                            }
-                                        });
-                                        if( $('#" + ddlTypes.ClientID + @"').val() > 2 )
-                                        { 
-                                             $('.hcSubtotalAmount').show(); 
-                                                
-                                            if( $('#" + ddlTypes.ClientID + @"').val() == 4)
-                                            {
-                                                $('.hc-label-amount').html('" + labelWeight + @"');          
-                                            }
-                                            else if($('#" + ddlTypes.ClientID + @"').val() == 3 )
-                                            {
-                                                $('.hc-label-amount').html('" + labelSubtotal +
-                             @"');                         
-                                            }
-                                        }
-                                        else
-                                        {
-                                             $('.hcSubtotalAmount').hide();                              
-                                             $('.hc-textbox-amount').val('0');   
-                                        }
-";
+                                if( $(this).val() == 4 )
+                                {
+                                    $('.hc-label-amount').html('" + labelWeight + @"');          
+                                }
+                                else if( $(this).val() == 3 )
+                                {
+                                    $('.hc-label-amount').html('" + labelSubtotal + @"');                         
+                                }
+                            }
+                            else
+                            {
+                                $('#" + pnlSecondDisplayRule.ClientID + @"').hide();
+                                $('.hcSubtotalAmount').hide();
+                                $('.hc-textbox-amount').val('0'); 
+                            }
+                        });
+                    if( $('#" + ddlTypes.ClientID + @"').val() > 2 )
+                    { 
+                        $('.hcSubtotalAmount').show();
+                        $('#" + pnlSecondDisplayRule.ClientID + @"').show();
+
+                        if ( $('#" + ddlTypes.ClientID + @"').val() == 4)
+                        {
+                            $('.hc-label-amount').html('" + labelWeight + @"');          
+                        }
+                        else if($('#" + ddlTypes.ClientID + @"').val() == 3 )
+                        {
+                            $('.hc-label-amount').html('" + labelSubtotal + @"');                         
+                        }
+                    }
+                    else
+                    {
+                        $('#" + pnlSecondDisplayRule.ClientID + @"').hide();
+                        $('.hcSubtotalAmount').hide();                              
+                        $('.hc-textbox-amount').val('0');   
+                    }";
 
                 pnlEditVisibility.Visible = true;
                 LoadSelectedItem(e.CommandArgument.ToString());
@@ -205,6 +209,21 @@ namespace Hotcakes.Modules.Core.Admin.Configuration
                     case ShippingVisibilityMode.TotalWeight:
                         lb.Text = string.Format(Localization.GetString("TotalWeight"), sm.VisibilityAmount);
                         break;
+                    case ShippingVisibilityMode.TotalWeightLessThan:
+                        lb.Text = string.Format(Localization.GetString("TotalWeightLessThan"), sm.VisibilityAmount);
+                        break;
+                }
+                switch (sm.VisibilityModeSecondary)
+                {
+                    case ShippingVisibilityMode.SubtotalAmount:
+                        lb.Text += string.Format(Localization.GetString("SubtotalAmountSecondary"), sm.VisibilityAmountSecondary);
+                        break;
+                    case ShippingVisibilityMode.TotalWeight:
+                        lb.Text += string.Format(Localization.GetString("TotalWeightSecondary"), sm.VisibilityAmountSecondary);
+                        break;
+                    case ShippingVisibilityMode.TotalWeightLessThan:
+                        lb.Text += string.Format(Localization.GetString("TotalWeightLessThanSecondary"), sm.VisibilityAmountSecondary);
+                        break;
                 }
             }
         }
@@ -247,6 +266,17 @@ namespace Hotcakes.Modules.Core.Admin.Configuration
                         item.VisibilityAmount = decimal.Parse(txtSubtotal.Text);
                     }
 
+                    var mode2 = int.Parse(ddlTypes2.SelectedValue);
+                    item.VisibilityModeSecondary = (ShippingVisibilityMode)mode2;
+                    if (mode2 > 0)
+                    {
+                        item.VisibilityAmountSecondary = decimal.Parse(txtSubtotal2.Text);
+                    }
+                    else
+                    {
+                        item.VisibilityAmountSecondary = null;
+                    }
+
                     HccApp.OrderServices.ShippingMethods.Update(item);
 
                     LoadMethods();
@@ -265,10 +295,12 @@ namespace Hotcakes.Modules.Core.Admin.Configuration
             lblMethodName.Text = item.Name;
 
             if (item.VisibilityMode == ShippingVisibilityMode.SubtotalAmount ||
-                item.VisibilityMode == ShippingVisibilityMode.TotalWeight)
+                item.VisibilityMode == ShippingVisibilityMode.TotalWeight ||
+                item.VisibilityMode == ShippingVisibilityMode.TotalWeightLessThan)
             {
                 if (item.VisibilityAmount.HasValue)
                 {
+                    pnlSecondDisplayRule.Visible = true;
                     txtSubtotal.Text = item.VisibilityAmount.Value.ToString("0.00");
                 }
                 else
@@ -281,7 +313,31 @@ namespace Hotcakes.Modules.Core.Admin.Configuration
                 txtSubtotal.Text = "0.00";
             }
 
+            if (item.VisibilityModeSecondary == ShippingVisibilityMode.SubtotalAmount ||
+                item.VisibilityModeSecondary == ShippingVisibilityMode.TotalWeight ||
+                item.VisibilityModeSecondary == ShippingVisibilityMode.TotalWeightLessThan)
+            {
+                if (item.VisibilityAmountSecondary.HasValue && item.VisibilityAmountSecondary.Value > 0)
+                {
+                    txtSubtotal2.Text = item.VisibilityAmountSecondary.Value.ToString("0.00");
+                }
+                else
+                {
+                    txtSubtotal2.Text = "0.00";
+                }
+            }
+            else
+            {
+                txtSubtotal2.Text = "0.00";
+            }
+
             ddlTypes.SelectedIndex = (int) item.VisibilityMode;
+
+            try
+            {
+                ddlTypes2.SelectedValue = ((int)item.VisibilityModeSecondary).ToString();
+            }
+            catch { ddlTypes2.SelectedValue = "-1"; }
         }
 
         private void LoadMethods()
@@ -326,6 +382,13 @@ namespace Hotcakes.Modules.Core.Admin.Configuration
         private void BindVisibilityTypes()
         {
             var list = new List<ListItem>();
+            var listSecondary = new List<ListItem>();
+
+            var liNone = new ListItem
+            {
+                Text = Localization.GetString("None"),
+                Value = "-1"
+            };
 
             var li = new ListItem
             {
@@ -345,9 +408,11 @@ namespace Hotcakes.Modules.Core.Admin.Configuration
                 Value = ((int) ShippingVisibilityMode.NoRates).ToString()
             };
 
-            var li4 = new ListItem {Text = string.Format(Localization.GetString("SubtotalAmount"), string.Empty)};
-            ;
-            li4.Value = ((int) ShippingVisibilityMode.SubtotalAmount).ToString();
+            var li4 = new ListItem
+            {
+                Text = string.Format(Localization.GetString("SubtotalAmount"), string.Empty),
+                Value = ((int) ShippingVisibilityMode.SubtotalAmount).ToString()
+            };
 
             var li5 = new ListItem
             {
@@ -355,16 +420,33 @@ namespace Hotcakes.Modules.Core.Admin.Configuration
                 Value = ((int) ShippingVisibilityMode.TotalWeight).ToString()
             };
 
+            var li6 = new ListItem
+            {
+                Text = string.Format(Localization.GetString("TotalWeightLessThan"), string.Empty),
+                Value = ((int) ShippingVisibilityMode.TotalWeightLessThan).ToString()
+            };
+
             list.Add(li);
             list.Add(li2);
             list.Add(li3);
             list.Add(li4);
             list.Add(li5);
+            list.Add(li6);
 
             ddlTypes.DataValueField = "Value";
             ddlTypes.DataTextField = "Text";
             ddlTypes.DataSource = list;
             ddlTypes.DataBind();
+
+            listSecondary.Add(liNone);
+            listSecondary.Add(li4);
+            listSecondary.Add(li5);
+            listSecondary.Add(li6);
+
+            ddlTypes2.DataValueField = "Value";
+            ddlTypes2.DataTextField = "Text";
+            ddlTypes2.DataSource = listSecondary;
+            ddlTypes2.DataBind();
         }
 
         #endregion

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Configuration/Shipping_Methods.aspx.designer.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Configuration/Shipping_Methods.aspx.designer.cs
@@ -121,6 +121,60 @@ namespace Hotcakes.Modules.Core.Admin.Configuration {
         protected global::System.Web.UI.WebControls.CompareValidator cvAmount;
         
         /// <summary>
+        /// pnlSecondDisplayRule control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel pnlSecondDisplayRule;
+        
+        /// <summary>
+        /// ddlTypes2 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.DropDownList ddlTypes2;
+        
+        /// <summary>
+        /// txtSubtotal2 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtSubtotal2;
+        
+        /// <summary>
+        /// rfvAmount2 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.RequiredFieldValidator rfvAmount2;
+        
+        /// <summary>
+        /// cvAmountSb2 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CompareValidator cvAmountSb2;
+        
+        /// <summary>
+        /// cvAmountSb control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CompareValidator cvAmountSb;
+        
+        /// <summary>
         /// btnSaveVisibility control.
         /// </summary>
         /// <remarks>

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Orders/Default.aspx
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Orders/Default.aspx
@@ -68,6 +68,9 @@
                     <asp:TextBox ID="FilterField" runat="server" />
                     <asp:LinkButton ID="btnGo" runat="server" Text="Filter Results" CssClass="hcIconRight" OnClick="btnGo_Click" />
                 </div>
+                <div class="hcFormItem hcUnderCheck">
+                    <asp:CheckBox ID="chkFilterIsOrderNum" runat="server" Checked="True" Text="Search criteria is an Order # (fast lookup)" AutoPostBack="False" />
+                </div>
             </div>
             <div class="hcFormItem">
                 <asp:DropDownList ID="lstStatus" runat="server" OnSelectedIndexChanged="lstStatus_SelectedIndexChanged" AutoPostBack="True">

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Orders/Default.aspx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Orders/Default.aspx.cs
@@ -182,9 +182,16 @@ namespace Hotcakes.Modules.Core.Admin.Orders
 			{
                 criteria.ShippingStatus = (OrderShippingStatus) int.Parse(lstShippingStatus.SelectedValue);
 			}
-			criteria.StartDateUtc = DateRangePicker1.StartDate.ToUniversalTime();
+		    if (chkFilterIsOrderNum.Checked)
+		    {
+                criteria.OrderNumber = FilterField.Text.Trim();
+            }
+		    else
+		    {
+		        criteria.Keyword = FilterField.Text.Trim();
+            }
+            criteria.StartDateUtc = DateRangePicker1.StartDate.ToUniversalTime();
 			criteria.EndDateUtc = DateRangePicker1.EndDate.ToUniversalTime();
-			criteria.Keyword = FilterField.Text.Trim();
 			criteria.SortDescending = chkNewestFirst.Checked;
 			criteria.IsIncludeCanceledOrder = true;
 			criteria.IncludeUnplaced = false;

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Orders/Default.aspx.designer.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Orders/Default.aspx.designer.cs
@@ -40,6 +40,15 @@ namespace Hotcakes.Modules.Core.Admin.Orders {
         protected global::System.Web.UI.WebControls.LinkButton btnGo;
         
         /// <summary>
+        /// chkFilterIsOrderNum control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CheckBox chkFilterIsOrderNum;
+        
+        /// <summary>
         /// lstStatus control.
         /// </summary>
         /// <remarks>

--- a/Website/DesktopModules/Hotcakes/Core/Admin/admin.css
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/admin.css
@@ -2166,6 +2166,16 @@ body > form {
   height: 53px;
   position: relative;
 }
+.hcNavContent .hcNavContentBody .hcBlock .hcForm .hcFormItem.hcUnderCheck {
+    top: -15px;
+    padding-bottom: 15px;
+}
+.hcNavContent .hcNavContentBody .hcBlock .hcForm .hcFormItem.hcUnderCheck input {
+    width: inherit;
+}
+.hcNavContent .hcNavContentBody .hcBlock .hcForm .hcFormItem.hcUnderCheck label {
+    display: contents;
+}
 .hcNavContent .hcNavContentBody .hcBlock .hcForm .hcFormItem.hcGo .hcFieldOuter input {
   position: absolute;
   color: #ffffff;

--- a/Website/DesktopModules/Hotcakes/Core/Areas/Account/Controllers/AddressBookController.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Areas/Account/Controllers/AddressBookController.cs
@@ -82,9 +82,17 @@ namespace Hotcakes.Modules.Core.Areas.Account.Controllers
 
                 var addr = LoadAddress(id);
                 UpdateAddressVm(ref model, formValues);
+
+                if (!TryValidateModel(model))
+                {
+                    model.Countries = HccApp.GlobalizationServices.Countries.FindActiveCountries();
+                    var country = HccApp.GlobalizationServices.Countries.Find(model.CountryBvin);
+                    model.Regions = country.Regions;
+
+                    return View(model);
+                }
                 model.CopyTo(addr);
 
-                var slug = id;
                 if (!u.UpdateAddress(addr))
                 {
                     HccApp.MembershipServices.CheckIfNewAddressAndAddWithUpdate(u, addr);
@@ -95,14 +103,9 @@ namespace Hotcakes.Modules.Core.Areas.Account.Controllers
             }
             catch (Exception ex)
             {
-
+                DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
+                return View(model);
             }
-
-            model.Countries = HccApp.GlobalizationServices.Countries.FindActiveCountries();
-            var country = HccApp.GlobalizationServices.Countries.Find(model.CountryBvin);
-            model.Regions = country.Regions;
-
-            return View(model);
         }
 
         [HttpPost]

--- a/Website/DesktopModules/Hotcakes/Core/Areas/Account/Controllers/AddressBookController.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Areas/Account/Controllers/AddressBookController.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using System.Reflection;
 using System.Web.Mvc;
 using Hotcakes.Commerce.Contacts;
+using Hotcakes.Commerce.Data.EF;
 using Hotcakes.Commerce.Extensions;
 using Hotcakes.Commerce.Globalization;
 using Hotcakes.Commerce.Shipping;
@@ -149,7 +150,8 @@ namespace Hotcakes.Modules.Core.Areas.Account.Controllers
             }
             else if (model.Countries != null && model.Countries.Any())
             {
-                countryCode = model.Countries.FirstOrDefault().Bvin;
+                countryCode = model.Countries.FirstOrDefault(c => c.CultureCode == "en-US").Bvin;
+                model.CountryBvin = countryCode;
             }
 
             if (!string.IsNullOrEmpty(countryCode))
@@ -213,22 +215,23 @@ namespace Hotcakes.Modules.Core.Areas.Account.Controllers
         {
             var user = HccApp.CurrentCustomer;
             var ret = new Address();
+            if (user == null) return ret;
 
-            if (user != null)
+            if (bvin.ToLower() == "new")
             {
-                if (bvin.ToLower() == "new")
+                ret = new Address
                 {
-                    ret = new Address
-                    {
-                        Bvin = Guid.NewGuid().ToString(),
-                        RegionBvin = string.Empty
-                    };
-                }
-                else
+                    Bvin = Guid.NewGuid().ToString(),
+                    RegionBvin = string.Empty
+                };
+            }
+            else
+            {
+                foreach (var a2 in user.Addresses)
                 {
-                    foreach (var a2 in user.Addresses)
+                    if (a2.Bvin == bvin)
                     {
-                        if (a2.Bvin == bvin) { ret = a2; }
+                        ret = a2;
                         break;
                     }
                 }

--- a/Website/DesktopModules/Hotcakes/Core/Controllers/CartController.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Controllers/CartController.cs
@@ -336,6 +336,34 @@ namespace Hotcakes.Modules.Core.Controllers
             return View(model);
         }
 
+        // GET: /MiniCart/
+        [NonCacheableResponseFilter]
+        public ActionResult MiniCart()
+        {
+            var model = new MiniCartViewModel
+            {
+                TotalQuantity = (CurrentCart != null && CurrentCart.Items != null) ? CurrentCart.Items.Count : 0
+            };
+
+            return View(model);
+        }
+
+        // POST: /MiniCartItems
+        [ActionName("MiniCartItems")]
+        [HccHttpPost]
+        public JsonResult GetMiniCartItems()
+        {
+            var model = IndexSetup();
+            HandleActionParams();
+            CheckForQuickAdd();
+            LoadCart(model);
+            ValidateOrderCoupons();
+            CheckFreeItems(model);
+            CheckForStockOnItems(model);
+
+            return Json(model);
+        }
+
         // POST: /Cart/
         [ActionName("Index")]
         [HccHttpPost]

--- a/Website/DesktopModules/Hotcakes/Core/Controllers/CartController.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Controllers/CartController.cs
@@ -342,7 +342,8 @@ namespace Hotcakes.Modules.Core.Controllers
         {
             var model = new MiniCartViewModel
             {
-                TotalQuantity = (CurrentCart != null && CurrentCart.Items != null) ? CurrentCart.Items.Count : 0
+                CartBvin = (CurrentCart != null && string.IsNullOrEmpty(CurrentCart.bvin)) ? CurrentCart.bvin : string.Empty,
+                TotalQuantity = CurrentCart?.Items?.Sum(x => x.Quantity) ?? 0
             };
 
             return View(model);

--- a/Website/DesktopModules/Hotcakes/Core/Models/MiniCartViewModel.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Models/MiniCartViewModel.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Hotcakes.Modules.Core.Models
+{
+    /// <summary>
+    ///     Represents the mini cart (pending order) shown on the cart page before checkout.
+    /// </summary>
+    [Serializable]
+    public class MiniCartViewModel
+    {
+        /// <summary>
+        ///     Set default values for each property.
+        /// </summary>
+        public MiniCartViewModel()
+        {
+            TotalQuantity = 0;
+        }
+
+        /// <summary>
+        ///     The total cont of items currently in the cart / order.
+        ///     To keep this lightweight we just return the number of items.
+        ///     Upon hover of the mini cart it will load the items in the cart.
+        /// </summary>
+        public int TotalQuantity { get; set; }
+    }
+}

--- a/Website/DesktopModules/Hotcakes/Core/Models/MiniCartViewModel.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Models/MiniCartViewModel.cs
@@ -25,5 +25,10 @@ namespace Hotcakes.Modules.Core.Models
         ///     Upon hover of the mini cart it will load the items in the cart.
         /// </summary>
         public int TotalQuantity { get; set; }
+
+        /// <summary>
+        ///     The current Cart ID (Order bvin)
+        /// </summary>
+        public string CartBvin { get; set; }
     }
 }

--- a/Website/DesktopModules/Hotcakes/Hotcakes.Modules.csproj
+++ b/Website/DesktopModules/Hotcakes/Hotcakes.Modules.csproj
@@ -2840,6 +2840,7 @@
       <DependentUpon>StoreNotFound.ascx</DependentUpon>
     </Compile>
     <Compile Include="Core\Models\PinterestViewModel.cs" />
+	<Compile Include="Core\Models\MiniCartViewModel.cs" />
     <Compile Include="Core\Performance.ashx.cs">
       <DependentUpon>Performance.ashx</DependentUpon>
     </Compile>

--- a/Website/DesktopModules/Hotcakes/MiniCart/MiniCartView.ascx.cs
+++ b/Website/DesktopModules/Hotcakes/MiniCart/MiniCartView.ascx.cs
@@ -32,10 +32,12 @@ namespace Hotcakes.Modules.MiniCart
     {
         protected override string RenderView()
         {
+            RegisterViewScript("MiniCart.js");
+
             var viewName = Convert.ToString(Settings["View"]);
             if (!string.IsNullOrEmpty(viewName))
-                return MvcRenderingEngine.Render("Cart", "Index");
-            return MvcRenderingEngine.Render("Cart", "Index", "MiniCart", new {MiniCart = true});
+                return MvcRenderingEngine.Render("Cart", "MiniCart", viewName);
+            return MvcRenderingEngine.Render("Cart", "MiniCart", "MiniCart", new {MiniCart = true});
         }
     }
 }

--- a/Website/Hotcakes.Views.csproj
+++ b/Website/Hotcakes.Views.csproj
@@ -26,6 +26,7 @@
     <SccProvider>SAK</SccProvider>
     <TargetFrameworkProfile />
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -177,6 +178,7 @@
     <Content Include="Portals\_default\HotcakesViews\_default\Scripts\EditBilling.js" />
     <Content Include="Portals\_default\HotcakesViews\_default\Scripts\EstimateShipping.js" />
     <Content Include="Portals\_default\HotcakesViews\_default\Scripts\ImageRotator.js" />
+    <Content Include="Portals\_default\HotcakesViews\_default\Scripts\MiniCart.js" />
     <Content Include="Portals\_default\HotcakesViews\_default\Scripts\OrderHistory.js" />
     <Content Include="Portals\_default\HotcakesViews\_default\Scripts\Pager.js" />
     <Content Include="Portals\_default\HotcakesViews\_default\Scripts\Products.js" />

--- a/Website/Portals/_default/HotcakesViews/_default/Areas/Account/Views/AddressBook/Edit.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default/Areas/Account/Views/AddressBook/Edit.cshtml
@@ -8,14 +8,18 @@
     @Html.ValidationSummary(true)
     @Html.Partial("_AddressEditor", Model)
  
-    <ul class="dnnActions">
-        <li>
-            <input type="submit" id="hcSaveAddress" value="@Localization.GetString("SaveChanges")" class="dnnPrimaryAction hcHandleNormalization"/>
-        </li>
-        <li>
-            <a href="@Url.RouteHccUrl(HccRoute.AddressBook)" class="dnnSecondaryAction">@Localization.GetString("Close")</a>
-        </li>
-    </ul>
-    
+    using (Html.BeginHccRouteForm(HccRoute.AddressBook, new {action = "edit", id = Model.Bvin }, FormMethod.Post))
+    {
+        <input type="hidden" id="hidUpdates" name="hidUpdates" />
+        <ul class="dnnActions">
+            <li>
+                <input type="submit" id="hcSaveAddress" value="@Localization.GetString("SaveChanges")" class="dnnPrimaryAction hcHandleNormalization"/>
+            </li>
+            <li>
+                <a href="@Url.RouteHccUrl(HccRoute.AddressBook)" class="dnnSecondaryAction">@Localization.GetString("Close")</a>
+            </li>
+        </ul>
+    }
+
 }
 </div>

--- a/Website/Portals/_default/HotcakesViews/_default/Scripts/AddressBook.js
+++ b/Website/Portals/_default/HotcakesViews/_default/Scripts/AddressBook.js
@@ -20,6 +20,7 @@
             this.$dialog = $form.find("#hcNormalizedAddressDlg");
             this.$dialogNormalizedAddr = this.$dialog.find(".hcNormalizedAddress");
             this.$dialogOriginalAddr = this.$dialog.find(".hcOriginalAddress");
+            this.$hidUpdates = $form.find("#hidUpdates");
 
             this.bindEvents();
             this.validateAddress();
@@ -36,7 +37,7 @@
             var self = this;
             var countryid = this.$formCountry.find(":selected").val();
 
-            $.post(API_GETREGIONS + "/"+ countryid, { "regionid": '' }, null, "json")
+            $.post(API_GETREGIONS + "/" + countryid, { "regionid": '' }, null, "json")
                 .done(function (data) { self.populateRegions(data.Regions); })
                 .fail(function () { })
                 .always(function () { });
@@ -49,6 +50,16 @@
         },
         addressChanged: function (e) {
             this.validateAddress();
+            var frmUpdateFlds = [];
+            const frmAll = $(this.$form).serializeArray();
+            $.each(frmAll, function (i, fld) {
+                switch (fld.name) {
+                case "hidUpdates": break; // don't add
+                default: frmUpdateFlds.push(fld.name + "=" + encodeURIComponent(fld.value));
+                }
+            });
+            const result = frmUpdateFlds.join("&");
+            $(this.$hidUpdates).val(result);
         },
         validateAddress: function (callback) {
             var self = this;
@@ -85,12 +96,12 @@
         },
         saveNormalized: function (e) {
             this.$formAddress.val(this.normalizedAddress.Line1),
-            this.$formAddress2.val(this.normalizedAddress.Line2),
-            this.$formCity.val(this.normalizedAddress.City),
-            this.$formZip.val(this.normalizedAddress.PostalCode),
-            this.$formState.val(this.normalizedAddress.RegionBvin),
+                this.$formAddress2.val(this.normalizedAddress.Line2),
+                this.$formCity.val(this.normalizedAddress.City),
+                this.$formZip.val(this.normalizedAddress.PostalCode),
+                this.$formState.val(this.normalizedAddress.RegionBvin),
 
-            this.$dialog.hcDialog("close");
+                this.$dialog.hcDialog("close");
             this.saveForm();
         },
         saveOriginal: function (e) {

--- a/Website/Portals/_default/HotcakesViews/_default/Scripts/App_LocalResources/ScriptResources.resx
+++ b/Website/Portals/_default/HotcakesViews/_default/Scripts/App_LocalResources/ScriptResources.resx
@@ -144,4 +144,7 @@
   <data name="common_AjaxError" xml:space="preserve">
     <value>Ajax error. Contact administrator</value>
   </data>
+  <data name="miniCart_SubTotal" xml:space="preserve">
+    <value>Sub Total</value>
+  </data>
 </root>

--- a/Website/Portals/_default/HotcakesViews/_default/Scripts/MiniCart.js
+++ b/Website/Portals/_default/HotcakesViews/_default/Scripts/MiniCart.js
@@ -1,0 +1,81 @@
+﻿jQuery(function ($) {
+    // Common ----------------------
+    var $target = $('#hcMiniCartTooltip');
+    var $minicart = $('#hcMiniCart');
+    var $iconbox = $minicart.find(".hc-iconbox");
+    var $cartActions = $('#hcMiniCartTooltip').find('.dnnActions');
+    var itemsRendered = false;
+
+    function InitCommon() {
+        if ($cartActions.length) {
+            $cartActions.hide();
+        }
+
+        if ($target.length) {
+            $minicart.hover(function () {
+                $iconbox.css("background-color", "#FFF");
+                $target.slideDown().position(
+                    'right'
+                );
+                LoadItems();
+            }, function () {
+                $target.slideUp(function () {
+                    $iconbox.css("background-color", "");
+                });
+            });
+        }
+    }
+
+    function LoadItems() {
+        if (itemsRendered)
+            return;
+
+        itemsRendered = true;
+        $.post(hcc.getServiceUrl("Cart/MiniCartItems"), {}, function (data) {
+            RenderMiniCartItems(data);
+            if ($cartActions.length) {
+                $cartActions.show();
+            }
+        });
+    }
+    
+    function RenderMiniCartItems(cartViewModel) {
+        $grid = $target.find('.dnnGrid');
+
+        if ($grid.length) {
+            $ajaxLoader = $grid.find('.hcAjaxLoader');
+
+            if ($ajaxLoader.length)
+                $ajaxLoader.remove();
+
+            var builtTable = '';
+            $.each(cartViewModel.LineItems, function (key, item) {
+                builtTable += '<tr><td>';
+                
+                if (item.ShowImage)
+                    builtTable += '<a href="' + item.LinkUrl + '" title="' + item.Item.ProductName + '"><img src="' + item.ImageUrl + '" alt="' + item.Item.ProductName + '" /></a>';
+                else
+                    builtTable += '&nbsp;';
+
+                builtTable += '</td>';
+
+                builtTable += '<td><a href="' + item.LinkUrl + '" title="' + item.Item.ProductName + '">' + item.Item.ProductName + '</a></td>';
+
+                builtTable += '<td>';
+                if (item.HasDiscounts) {
+                    builtTable += '<div class="hc-discount">$' + item.Item.LineTotalWithoutDiscounts.toFixed(2) + '</div>';
+                }
+                builtTable += '$' + item.Item.LineTotal.toFixed(2);
+                builtTable += '</td></tr>';
+            });
+
+            builtTable += '<tr class="hc-subtotal"><td colspan="2">' + hcc.l10n.miniCart_SubTotal + '</td><td>$' + cartViewModel.CurrentOrder.TotalOrderBeforeDiscounts.toFixed(2) + '</td></tr>';
+
+            $grid.append(builtTable);
+        }
+    }
+
+    $(document).ready(function () {
+        InitCommon();
+    });
+});

--- a/Website/Portals/_default/HotcakesViews/_default/Views/Cart/MiniCart.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default/Views/Cart/MiniCart.cshtml
@@ -1,74 +1,18 @@
-﻿@model Hotcakes.Modules.Core.Models.CartViewModel
-<script type="text/javascript">
-    $(function () {
-        var $target = $('#hcMiniCartTooltip');
-        var $minicart = $('#hcMiniCart');
-        var $iconbox = $minicart.find(".hc-iconbox");
-
-        if ($target.length) {
-            $minicart.hover(function () {
-                $iconbox.css("background-color", "#FFF");
-                $target.slideDown().position(
-                    'right'
-                );
-            }, function () {
-                $target.slideUp(function () {
-                    $iconbox.css("background-color", "");
-                });
-            });
-        }
-    });
-</script>
-
+﻿@model Hotcakes.Modules.Core.Models.MiniCartViewModel
 <div id="hcMiniCart" class="hc-minicart">
     <div class="hc-iconbox">
         <a href="@Url.RouteHccUrl(HccRoute.Cart)">
-            @Model.CurrentOrder.TotalQuantity
+            @Model.TotalQuantity
         </a>
     </div>
-    @if (!Model.CartEmpty)
+    @if (Model.TotalQuantity > 0)
     {
         <div class="hc-tooltip dnnFormPopup" id="hcMiniCartTooltip">
-            @Model.ItemListTitle
             <h2>@Localization.GetString("ShoppingCart")</h2>
 
             <table class="dnnGrid" width="100%">
-                @foreach (var item in Model.LineItems)
-                {
-                    <tr>
-                        <td>
-                            @if (item.ShowImage)
-                            {
-                                <a href="@item.LinkUrl" title="@item.Item.ProductName">
-                                    <img src="@item.ImageUrl" alt="@item.Item.ProductName" />
-                                </a>
-                            }
-                            else
-                            {
-                                <text>&nbsp;</text>
-                            }
-                        </td>
-                        <td>
-                            <a href="@item.LinkUrl" title="@item.Item.ProductName">
-                                @item.Item.ProductName
-                            </a>
-                        </td>
-                        <td>
-                            @if (item.HasDiscounts)
-                            {
-                                <div class="hc-discount">@item.Item.LineTotalWithoutDiscounts.ToString("c")</div>
-                            }
-                            @item.Item.LineTotal.ToString("c")
-                        </td>
-                    </tr>
-                }
-                <tr class="hc-subtotal">
-                    <td colspan="2">
-                        @Localization.GetString("Subtotal")
-                    </td>
-                    <td>
-                        @string.Format("{0:c}", Model.CurrentOrder.TotalOrderBeforeDiscounts)
-                    </td>
+                <tr class="hcAjaxLoader">
+                    <td><p>&nbsp;</p></td>
                 </tr>
             </table>
 

--- a/Website/web.config
+++ b/Website/web.config
@@ -28,6 +28,7 @@
     </sectionGroup>
     <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor">
       <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor" requirePermission="false" />
+      <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor" requirePermission="false" />
     </sectionGroup>
     <section name="clientDependency" type="ClientDependency.Core.Config.ClientDependencySection, ClientDependency.Core" requirePermission="false" />
   </configSections>


### PR DESCRIPTION
Overview:
This change fixes the issue we found for the Paypal Express whereby an order will process from a Hold despite the fact that the user's primary and backup funding source had insufficient funds.

Issue as reported:
Our client received an order from Hotcakes to there ERP that had a failed Paypal Hold authorization.  The checkout process should not allowed an order to go through with a failed authorization.  Therefore they had to contact the customer for payment.

How to recreate:
1) In Hotcakes admin, enable Paypal Express payment option and select the "Hold" option for the fund type
2) Create a Paypal sandbox user that has a valid, verified account with a backup credit card funding source.  Ensure the user account does not have sufficient funds for a purchase.  In addition, ensure the test user's backup funding source does not have sufficient funds.
3) Checkout using the Paypal Express method.  Notice the order will complete and in the Hotcakes Order admin, the Payment transactions will show the failed Hold authorization.

This Pull Request Fix:
My fix will inspect the response of the Paypal authorize call and if it was unsuccessful, it will include that as part of setting the OrderTransaction.Success flag rather than just ignoring it.  That will return the user back to checkout page to try the payment again.

Thanks!
Scott
