### PR TITLE
(Issue #193)  Category Sorting Not Working in Admin

### DIFF
--- a/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Categories.js
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Categories.js
@@ -27,6 +27,8 @@ $(document).ready(function () {
             containment: 'parent',
             opacity: '0.75',
             cursor: 'move',
+            forcePlaceholderSize: true,
+            tolerance: 'pointer',
             update: function (event, ui) {
                 var sorted = $(this).sortable('toArray');
                 sorted += '';


### PR DESCRIPTION
The parent object was losing it's hieght when the child objects were being moved.  This corrects it by setting forcePlaceholderSize to true and the tolerance to 'pointer'.