### PR TITLE
Localization of Sitemaps - fixes #269

### DIFF
--- a/Libraries/Hotcakes.Commerce.Dnn/Providers/ProductsSitemapProvider.cs
+++ b/Libraries/Hotcakes.Commerce.Dnn/Providers/ProductsSitemapProvider.cs
@@ -29,6 +29,7 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Services.Sitemap;
 using Hotcakes.Commerce.Catalog;
 using Hotcakes.Commerce.Urls;
+using Hotcakes.Commerce.Utilities;
 
 namespace Hotcakes.Commerce.Dnn.Providers
 {
@@ -42,10 +43,17 @@ namespace Hotcakes.Commerce.Dnn.Providers
 
             var urls = new List<SitemapUrl>();
             SitemapUrl pageUrl = null;
+
+            if (HccRequestContext.Current != null) // Localize HccRequestContext
+                HccRequestContext.Current = HccRequestContextUtils.GetContextWithCulture(HccRequestContext.Current, ps.CultureCode);
+
             foreach (var product in products)
             {
-                pageUrl = GetPageUrl(product);
-                urls.Add(pageUrl);
+                if (product.IsAvailableForSale)
+                {
+                    pageUrl = GetPageUrl(product);
+                    urls.Add(pageUrl);
+                }                
             }
 
             return urls;

--- a/Libraries/Hotcakes.Commerce.Dnn/Providers/ProductsSitemapProvider.cs
+++ b/Libraries/Hotcakes.Commerce.Dnn/Providers/ProductsSitemapProvider.cs
@@ -49,11 +49,8 @@ namespace Hotcakes.Commerce.Dnn.Providers
 
             foreach (var product in products)
             {
-                if (product.IsAvailableForSale)
-                {
-                    pageUrl = GetPageUrl(product);
-                    urls.Add(pageUrl);
-                }                
+                pageUrl = GetPageUrl(product);
+                urls.Add(pageUrl);           
             }
 
             return urls;

--- a/Libraries/Hotcakes.Commerce.Dnn/Providers/ProductsSitemapProvider.cs
+++ b/Libraries/Hotcakes.Commerce.Dnn/Providers/ProductsSitemapProvider.cs
@@ -50,7 +50,7 @@ namespace Hotcakes.Commerce.Dnn.Providers
             foreach (var product in products)
             {
                 pageUrl = GetPageUrl(product);
-                urls.Add(pageUrl);           
+                urls.Add(pageUrl);
             }
 
             return urls;


### PR DESCRIPTION
Fix for #269 
Localizes HccRequestContext in the SitemapProvider for localized TabIDs