### PR TITLE
Fixes #346

### DIFF
--- a/Website/Portals/_default/HotcakesViews/_default/Scripts/AffiliateDashboard.js
+++ b/Website/Portals/_default/HotcakesViews/_default/Scripts/AffiliateDashboard.js
@@ -300,7 +300,7 @@ $(function () {
     });
 
     $("#hcCopyToClipboard").click(function (e) {
-        e.preventDefault();
+        return false;
     });
 
     var clipboard = new ClipboardJS("#hcCopyToClipboard");

--- a/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateDashboard/_UrlBuilder.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateDashboard/_UrlBuilder.cshtml
@@ -33,7 +33,7 @@
             </div>
             <div class="form-group">
                 <div class="col-xs-offset-4 col-xs-6 text-left">
-                    <button class="btn btn-primary" data-bind="click: generate"><em class="glyphicon glyphicon-link"></em>@Localization.GetString("btnGenerate")</button>
+                    <button class="btn btn-primary" data-bind="click: generate, clickBubble: false"><em class="glyphicon glyphicon-link"></em>@Localization.GetString("btnGenerate")</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #346 

The ajax request was reloading the page, preventing the user from being able to see and use the urls that were generated. This fix will resolve that issue in the default template to allow to see and use the url that is generated and copy it to their clipboard.