### PR TITLE
Fixes Transaction.Items is null first time ProcessTransaction is called

### DIFF
--- a/Libraries/Hotcakes.Commerce/BusinessRules/OrderTasks/ReceiveCreditCards.cs
+++ b/Libraries/Hotcakes.Commerce/BusinessRules/OrderTasks/ReceiveCreditCards.cs
@@ -108,11 +108,12 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
 			try
 			{
 				var payManager = new OrderPaymentManager(context.Order, context.HccApp);
+                var orderNumber = !string.IsNullOrEmpty(p.OrderNumber) ? p.OrderNumber : context.Order.OrderNumber;
 				Transaction t = payManager.CreateEmptyTransaction();
 				t.Card = p.CreditCard;
 				t.Card.SecurityCode = context.Inputs.GetProperty("hcc", "CardSecurityCode");
 				t.Amount = p.Amount;
-                t.Items = GetLineItemsForTransaction(context, p.OrderNumber);
+                t.Items = GetLineItemsForTransaction(context, orderNumber);
 
 				if (context.HccApp.CurrentStore.Settings.PaymentCreditCardAuthorizeOnly)
 				{


### PR DESCRIPTION
Resolves #345 by using the OrderTaskContext.Order.OrderNumber as a fallback in case the OrderNumber on the Transaction object is empty