### PR TITLE
Fix for RedirectToCheckout parameter

### DIFF
--- a/Website/DesktopModules/Hotcakes/Core/Controllers/CartController.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Controllers/CartController.cs
@@ -325,7 +325,11 @@ namespace Hotcakes.Modules.Core.Controllers
         public ActionResult Index()
         {
             var model = IndexSetup();
-            HandleActionParams();
+            var redirectResult = HandleActionParams();
+            if (redirectResult != null && (redirectResult?.Url != Redirect(Url.RouteHccUrl(HccRoute.Cart)).Url))
+            {
+                return Redirect(redirectResult.Url);
+            }
             CheckForQuickAdd();
             LoadCart(model);
             ValidateOrderCoupons();
@@ -583,7 +587,7 @@ namespace Hotcakes.Modules.Core.Controllers
                 {
                     var redirect = bool.Parse(RedirectToCheckout);
                     if (redirect)
-                        Redirect(Url.RouteHccUrl(HccRoute.Checkout));
+                        return Redirect(Url.RouteHccUrl(HccRoute.Checkout));
                 }
                 return Redirect(Url.RouteHccUrl(HccRoute.Cart));
 


### PR DESCRIPTION
Fixes #350 
Checks the RedirectResult from the HandleActionParams() and if it's something other than the Cart page, it redirects, otherwise it continues with loading the Shopping Cart