### PR TITLE
Fix #292 - Affiliate & Category (drilldown) views don't work

### DIFF
--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyBootstrap4/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyBootstrap4/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
@@ -201,4 +201,7 @@
   <data name="AffiliateIdHelp.Text" xml:space="preserve">
     <value>Letters and numbers only, please</value>
   </data>
+  <data name="ValMessage_ConfirmTerms.Text" xml:space="preserve">
+    <value>Please agree to the Terms and Conditions</value>
+  </data>
 </root>

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyBootstrap4/Views/AffiliateRegistration/Index.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyBootstrap4/Views/AffiliateRegistration/Index.cshtml
@@ -184,8 +184,10 @@
                                     </label>
                                     <div class="col-sm-6 offset-sm-0">
                                         <div class="form-check dnnFormRequired">
-                                            @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms", @class="form-check-input" })
+                                            @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms", @class = "form-check-input" })
                                             <label class="form-check-label" for="ConfirmTerms">@Localization.GetString("lblIAgreeTo")</label>
+                                            @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "alert alert-danger" })
+                                            @Html.HiddenFor(model => model.IsTrue)
                                         </div>
                                         <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="btn btn-outline-info btn-sm hc-popup">
                                             <i class="fas fa-book"></i>@Localization.GetString("lblAffiliateTerms") 

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyBootstrap4/Views/AffiliateRegistration/Index.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyBootstrap4/Views/AffiliateRegistration/Index.cshtml
@@ -220,7 +220,9 @@
                         </div>
                     }
                     else{
-                        Html.Raw(Model.AgreementText);
+                        <text>
+                        @Html.Raw(Model.AgreementText)
+                        </text>
                     }
                 </div>
                 <p class="text-right mt-3">

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyLegacy/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyLegacy/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
@@ -189,4 +189,7 @@
   <data name="lblLastName.Text" xml:space="preserve">
     <value>Last Name:</value>
   </data>
+  <data name="ValMessage_ConfirmTerms.Text" xml:space="preserve">
+    <value>Please agree to the Terms and Conditions</value>
+  </data>
 </root>

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyLegacy/Views/AffiliateRegistration/Index.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyLegacy/Views/AffiliateRegistration/Index.cshtml
@@ -166,7 +166,16 @@
 @* Affiliate Terms Popup *@
 <div id="hcAffiliateTermsPopup" style="display: none;">
     <div class="hc-affiliate-terms">
-        @Html.Raw(@Model.AgreementText)
+        @if (Model.AgreementText == ""){
+            <div class="alert alert-warning">
+                @Localization.GetString("NoAgreement")
+            </div>
+        }
+        else{
+            <text>
+            @Html.Raw(Model.AgreementText)
+            </text>
+        }
     </div>
     <ul class="dnnActions dnnRight">
         <li>

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyLegacy/Views/AffiliateRegistration/Index.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyLegacy/Views/AffiliateRegistration/Index.cshtml
@@ -94,7 +94,9 @@
                 </label>
                 <label>
                     @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms" })
-                    @Localization.GetString("lblIAgreeTo") 
+                    @Localization.GetString("lblIAgreeTo")
+                    @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "dnnFormMessage hcFormError" })
+                    @Html.HiddenFor(model => model.IsTrue)
                 </label>
                 <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="hc-popup">@Localization.GetString("lblAffiliateTerms") </a>
             </div>

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyViewSet/Views/AffiliateRegistration/Index.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyViewSet/Views/AffiliateRegistration/Index.cshtml
@@ -216,7 +216,9 @@
                     </div>
                 }
                 else{
-                    Html.Raw(Model.AgreementText);
+                    <text>
+                    @Html.Raw(Model.AgreementText)
+                    </text>
                 }
             </div>
             <p class="text-right margin-top-md">

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyViewSet/Views/AffiliateRegistration/Index.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyViewSet/Views/AffiliateRegistration/Index.cshtml
@@ -184,7 +184,9 @@
                             <div class="checkbox dnnFormRequired">
                                 <label>
                                     @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms" })
-                                    @Localization.GetString("lblIAgreeTo") 
+                                    @Localization.GetString("lblIAgreeTo")
+                                    @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "alert alert-danger" })
+                                    @Html.HiddenFor(model => model.IsTrue)
                                 </label>
                             </div>
                             <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="btn btn-default btn-sm hc-popup">

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/Porto5/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/Porto5/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
@@ -201,4 +201,7 @@
   <data name="AffiliateIdHelp.Text" xml:space="preserve">
     <value>Letters and numbers only, please</value>
   </data>
+  <data name="ValMessage_ConfirmTerms.Text" xml:space="preserve">
+    <value>Please agree to the Terms and Conditions</value>
+  </data>
 </root>

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/Porto5/Views/AffiliateRegistration/Index.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/Porto5/Views/AffiliateRegistration/Index.cshtml
@@ -186,6 +186,8 @@
                                         <div class="form-check dnnFormRequired">
                                             @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms", @class="form-check-input" })
                                             <label class="form-check-label" for="ConfirmTerms">@Localization.GetString("lblIAgreeTo")</label>
+                                            @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "alert alert-danger" })
+                                            @Html.HiddenFor(model => model.IsTrue)
                                         </div>
                                         <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="btn btn-outline-info btn-sm hc-popup">
                                             <i class="fas fa-book"></i>@Localization.GetString("lblAffiliateTerms") 

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
@@ -189,4 +189,7 @@
   <data name="lblLastName.Text" xml:space="preserve">
     <value>Last Name:</value>
   </data>
+  <data name="ValMessage_ConfirmTerms.Text" xml:space="preserve">
+    <value>Please agree to the Terms and Conditions</value>
+  </data>
 </root>

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/Index.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/Index.cshtml
@@ -166,7 +166,16 @@
 @* Affiliate Terms Popup *@
 <div id="hcAffiliateTermsPopup" style="display: none;">
     <div class="hc-affiliate-terms">
-        @Html.Raw(@Model.AgreementText)
+        @if (Model.AgreementText == ""){
+            <div class="alert alert-warning">
+                @Localization.GetString("NoAgreement")
+            </div>
+        }
+        else{
+            <text>
+            @Html.Raw(Model.AgreementText)
+            </text>
+        }
     </div>
     <ul class="dnnActions dnnRight">
         <li>

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/Index.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/Index.cshtml
@@ -94,7 +94,9 @@
                 </label>
                 <label>
                     @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms" })
-                    @Localization.GetString("lblIAgreeTo") 
+                    @Localization.GetString("lblIAgreeTo")
+                    @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "dnnFormMessage hcFormError" })
+                    @Html.HiddenFor(model => model.IsTrue)
                 </label>
                 <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="hc-popup">@Localization.GetString("lblAffiliateTerms") </a>
             </div>

--- a/Libraries/Hotcakes.Shipping/USPSAddressProvider.cs
+++ b/Libraries/Hotcakes.Shipping/USPSAddressProvider.cs
@@ -34,7 +34,7 @@ namespace Hotcakes.Shipping
 {
     public class USPSAddressProvider : IAddressProvider
     {
-        private const string _url = "http://production.shippingapis.com/ShippingAPITest.dll?API=Verify&XML=";
+        private const string _url = "https://production.shippingapis.com/ShippingAPITest.dll?API=Verify&XML=";
         private readonly string _userID;
 
         public USPSAddressProvider(string userID)

--- a/Website/DesktopModules/Hotcakes/Core/Models/AffiliateViewModel.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Models/AffiliateViewModel.cs
@@ -166,9 +166,12 @@ namespace Hotcakes.Modules.Core.Models
         [RegularExpression(@"[-\w]*", ErrorMessage = "Only alpha-numeric and '-', '_' characters are allowed")]
         public string ReferralAffiliateId { get; set; }
 
+        public bool IsTrue => true;
+
         /// <summary>
         ///     Checkbox to confirm the terms
         /// </summary>
+        [Compare(nameof(IsTrue), ErrorMessage = "Please agree to Terms and Conditions")]
         public bool ConfirmTerms { get; set; }
 
         /// <summary>

--- a/Website/DesktopModules/Hotcakes/Core/Models/AffiliateViewModel.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Models/AffiliateViewModel.cs
@@ -166,7 +166,7 @@ namespace Hotcakes.Modules.Core.Models
         [RegularExpression(@"[-\w]*", ErrorMessage = "Only alpha-numeric and '-', '_' characters are allowed")]
         public string ReferralAffiliateId { get; set; }
 
-        public bool IsTrue => true;
+        public bool IsTrue { get { return true; } }
 
         /// <summary>
         ///     Checkbox to confirm the terms

--- a/Website/Portals/_default/HotcakesViews/Bootstrap4/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
+++ b/Website/Portals/_default/HotcakesViews/Bootstrap4/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
@@ -201,4 +201,7 @@
   <data name="AffiliateIdHelp.Text" xml:space="preserve">
     <value>Letters and numbers only, please</value>
   </data>
+  <data name="ValMessage_ConfirmTerms.Text" xml:space="preserve">
+    <value>Please agree to the Terms and Conditions</value>
+  </data>
 </root>

--- a/Website/Portals/_default/HotcakesViews/Bootstrap4/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/Bootstrap4/Views/AffiliateRegistration/Index.cshtml
@@ -184,8 +184,10 @@
                                     </label>
                                     <div class="col-sm-6 offset-sm-0">
                                         <div class="form-check dnnFormRequired">
-                                            @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms", @class="form-check-input" })
+                                            @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms", @class = "form-check-input" })
                                             <label class="form-check-label" for="ConfirmTerms">@Localization.GetString("lblIAgreeTo")</label>
+                                            @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "alert alert-danger" })
+                                            @Html.HiddenFor(model => model.IsTrue)
                                         </div>
                                         <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="btn btn-outline-info btn-sm hc-popup">
                                             <i class="fas fa-book"></i>@Localization.GetString("lblAffiliateTerms") 

--- a/Website/Portals/_default/HotcakesViews/Bootstrap4/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/Bootstrap4/Views/AffiliateRegistration/Index.cshtml
@@ -220,7 +220,9 @@
                         </div>
                     }
                     else{
-                        Html.Raw(Model.AgreementText);
+                        <text>
+                        @Html.Raw(Model.AgreementText)
+                        </text>
                     }
                 </div>
                 <p class="text-right mt-3">

--- a/Website/Portals/_default/HotcakesViews/Porto5/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
+++ b/Website/Portals/_default/HotcakesViews/Porto5/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
@@ -201,4 +201,7 @@
   <data name="AffiliateIdHelp.Text" xml:space="preserve">
     <value>Letters and numbers only, please</value>
   </data>
+  <data name="ValMessage_ConfirmTerms.Text" xml:space="preserve">
+    <value>Please agree to the Terms and Conditions</value>
+  </data>
 </root>

--- a/Website/Portals/_default/HotcakesViews/Porto5/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/Porto5/Views/AffiliateRegistration/Index.cshtml
@@ -184,8 +184,10 @@
                                     </label>
                                     <div class="col-sm-6 offset-sm-0">
                                         <div class="form-check dnnFormRequired">
-                                            @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms", @class="form-check-input" })
+                                            @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms", @class = "form-check-input" })
                                             <label class="form-check-label" for="ConfirmTerms">@Localization.GetString("lblIAgreeTo")</label>
+                                            @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "alert alert-danger" })
+                                            @Html.HiddenFor(model => model.IsTrue)
                                         </div>
                                         <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="btn btn-outline-info btn-sm hc-popup">
                                             <i class="fas fa-book"></i>@Localization.GetString("lblAffiliateTerms") 
@@ -218,7 +220,9 @@
                         </div>
                     }
                     else{
-                        Html.Raw(Model.AgreementText);
+                        <text>
+                        @Html.Raw(Model.AgreementText)
+                        </text>
                     }
                 </div>
                 <p class="text-right mt-3">

--- a/Website/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
+++ b/Website/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
@@ -189,4 +189,7 @@
   <data name="lblLastName.Text" xml:space="preserve">
     <value>Last Name:</value>
   </data>
+  <data name="ValMessage_ConfirmTerms.Text" xml:space="preserve">
+    <value>Please agree to the Terms and Conditions</value>
+  </data>
 </root>

--- a/Website/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/Index.cshtml
@@ -166,7 +166,18 @@
 @* Affiliate Terms Popup *@
 <div id="hcAffiliateTermsPopup" style="display: none;">
     <div class="hc-affiliate-terms">
-        @Html.Raw(@Model.AgreementText)
+        @if (Model.AgreementText == "")
+        {
+            <div class="alert alert-warning">
+                @Localization.GetString("NoAgreement")
+            </div>
+        }
+        else
+        {
+            <text>
+            @Html.Raw(Model.AgreementText)
+            </text>
+        }
     </div>
     <ul class="dnnActions dnnRight">
         <li>

--- a/Website/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/SocialSpokes/Views/AffiliateRegistration/Index.cshtml
@@ -94,7 +94,9 @@
                 </label>
                 <label>
                     @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms" })
-                    @Localization.GetString("lblIAgreeTo") 
+                    @Localization.GetString("lblIAgreeTo")
+                    @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "dnnFormMessage hcFormError" })
+                    @Html.HiddenFor(model => model.IsTrue)
                 </label>
                 <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="hc-popup">@Localization.GetString("lblAffiliateTerms") </a>
             </div>

--- a/Website/Portals/_default/HotcakesViews/_default-Legacy/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
+++ b/Website/Portals/_default/HotcakesViews/_default-Legacy/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
@@ -189,4 +189,7 @@
   <data name="lblLastName.Text" xml:space="preserve">
     <value>Last Name:</value>
   </data>
+  <data name="ValMessage_ConfirmTerms.Text" xml:space="preserve">
+    <value>Please agree to the Terms and Conditions</value>
+  </data>
 </root>

--- a/Website/Portals/_default/HotcakesViews/_default-Legacy/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default-Legacy/Views/AffiliateRegistration/Index.cshtml
@@ -166,7 +166,18 @@
 @* Affiliate Terms Popup *@
 <div id="hcAffiliateTermsPopup" style="display: none;">
     <div class="hc-affiliate-terms">
-        @Html.Raw(@Model.AgreementText)
+        @if (Model.AgreementText == "")
+        {
+            <div class="alert alert-warning">
+                @Localization.GetString("NoAgreement")
+            </div>
+        }
+        else
+        {
+            <text>
+                @Html.Raw(Model.AgreementText)
+            </text>
+        }
     </div>
     <ul class="dnnActions dnnRight">
         <li>

--- a/Website/Portals/_default/HotcakesViews/_default-Legacy/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default-Legacy/Views/AffiliateRegistration/Index.cshtml
@@ -94,7 +94,9 @@
                 </label>
                 <label>
                     @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms" })
-                    @Localization.GetString("lblIAgreeTo") 
+                    @Localization.GetString("lblIAgreeTo")
+                    @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "dnnFormMessage hcFormError" })
+                    @Html.HiddenFor(model => model.IsTrue)
                 </label>
                 <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="hc-popup">@Localization.GetString("lblAffiliateTerms") </a>
             </div>

--- a/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
+++ b/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/App_LocalResources/Index.cshtml.resx
@@ -201,4 +201,7 @@
   <data name="AffiliateIdHelp.Text" xml:space="preserve">
     <value>Letters and numbers only, please</value>
   </data>
+  <data name="ValMessage_ConfirmTerms.Text" xml:space="preserve">
+    <value>Please agree to Terms and Conditions</value>
+  </data>
 </root>

--- a/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/Index.cshtml
@@ -183,9 +183,10 @@
                         <div class="col-offset-0 col-xs-6">
                             <div class="checkbox dnnFormRequired">
                                 <label>
-                                    @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms" })
+                                    @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms", ID = "chkConfirmTerms" })
                                     @Localization.GetString("lblIAgreeTo")
-                                    @Html.ValidationMessageFor(model => model.ConfirmTerms, "", new { @class = "alert alert-danger" })
+                                    @Html.ValidationMessageFor(model => model.ConfirmTerms, Localization.GetString("ValMessage_ConfirmTerms"), new { @class = "alert alert-danger" })
+                                    @Html.HiddenFor(model => model.IsTrue)
                                 </label>
                             </div>
                             <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="btn btn-default btn-sm hc-popup">
@@ -236,4 +237,16 @@
             $(".hcAffiliateReg")[0]
         );
     });
+</script>
+
+<script>
+    $(function () {
+        $("#chkConfirmTerms").change(function () {
+            CheckedIsActive();
+        });
+    });
+
+    function CheckedIsActive() {
+        $("#ConfirmTerms").attr("checked", true);
+    }
 </script>

--- a/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/Index.cshtml
@@ -209,13 +209,15 @@
     <div class="row-fluid">
         <div class="col-xs-12">
             <div class="hc-affiliate-terms margin-top-lg">
-                @if (string.IsNullOrEmpty(Model.AgreementText)){
+                @if (Model.AgreementText == ""){
                     <div class="alert alert-warning">
                         @Localization.GetString("NoAgreement")
                     </div>
                 }
                 else{
-                    Html.Raw(Model.AgreementText);
+                    <text>
+                    @Html.Raw(Model.AgreementText)
+                    </text>
                 }
             </div>
             <p class="text-right margin-top-md">

--- a/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/Index.cshtml
@@ -238,15 +238,3 @@
         );
     });
 </script>
-
-<script>
-    $(function () {
-        $("#chkConfirmTerms").change(function () {
-            CheckedIsActive();
-        });
-    });
-
-    function CheckedIsActive() {
-        $("#ConfirmTerms").attr("checked", true);
-    }
-</script>

--- a/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/Index.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default/Views/AffiliateRegistration/Index.cshtml
@@ -184,7 +184,8 @@
                             <div class="checkbox dnnFormRequired">
                                 <label>
                                     @Html.CheckBoxFor(model => model.ConfirmTerms, new { data_bind = "checked: model.confirmterms" })
-                                    @Localization.GetString("lblIAgreeTo") 
+                                    @Localization.GetString("lblIAgreeTo")
+                                    @Html.ValidationMessageFor(model => model.ConfirmTerms, "", new { @class = "alert alert-danger" })
                                 </label>
                             </div>
                             <a href="#hcAffiliateTermsPopup" data-min-width="600" data-min-height="350" title="@Localization.GetString("TermsTitle")" class="btn btn-default btn-sm hc-popup">
@@ -208,7 +209,7 @@
     <div class="row-fluid">
         <div class="col-xs-12">
             <div class="hc-affiliate-terms margin-top-lg">
-                @if (Model.AgreementText == ""){
+                @if (string.IsNullOrEmpty(Model.AgreementText)){
                     <div class="alert alert-warning">
                         @Localization.GetString("NoAgreement")
                     </div>


### PR DESCRIPTION
Fix #292 include :
- Javascript issue due missing validation for Confirm Terms
- Term Popup show nothing event if affiliate agreement terms been fill in

Tested on :
- Default Theme
- Porto Theme