### PR TITLE
Update _CreditCardInput.cshtml

### DIFF
--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyBootstrap4/Views/Checkout/_CreditCardInput.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyBootstrap4/Views/Checkout/_CreditCardInput.cshtml
@@ -60,7 +60,7 @@
         <div class="col-sm-6 offset-sm-0">
             <input type="text" name="cccardnumber" id="cccardnumber" maxlength="20"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="form-control @Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="form-control @Model.IsErr("cccardnumber")" autocomplete="cc-csc" />
         </div>
     </div>
     <div class="form-group row">

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyLegacy/Views/Checkout/_CreditCardInput.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyLegacy/Views/Checkout/_CreditCardInput.cshtml
@@ -58,7 +58,7 @@
         <input type="text" name="cccardnumber" id="cccardnumber" size="20" maxlength="20"
                 tabindex="501"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="@Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="@Model.IsErr("cccardnumber")" autocomplete="cc-csc" />
 
     </div>
     <div class="dnnFormItem">

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyViewSet/Views/Checkout/_CreditCardInput.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyViewSet/Views/Checkout/_CreditCardInput.cshtml
@@ -60,7 +60,7 @@
         <div class="col-sm-offset-0 col-sm-6">
             <input type="text" name="cccardnumber" id="cccardnumber" maxlength="20"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="form-control @Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="form-control @Model.IsErr("cccardnumber")" autocomplete="cc-csc" />
         </div>
     </div>
     <div class="form-group">

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyViewSet/Views/Views/Checkout/_CreditCardInput.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/MyViewSet/Views/Views/Checkout/_CreditCardInput.cshtml
@@ -56,7 +56,7 @@
     <div class="form-group dnnFormRequired">
         <label class="col-sm-4 control-label" for="cccardnumber">@Localization.GetString("CardNumber"):</label>
         <div class="col-sm-offset-0 col-sm-6">
-            <input type="text" name="cccardnumber" id="cccardnumber" maxlength="20"
+            <input type="text" name="cccardnumber" id="cccardnumber" maxlength="20" autocomplete="cc-csc"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
                 class="form-control @Model.IsErr("cccardnumber")" />
         </div>

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/Porto5/Views/Checkout/_CreditCardInput.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/Porto5/Views/Checkout/_CreditCardInput.cshtml
@@ -60,7 +60,7 @@
         <div class="col-sm-6 offset-sm-0">
             <input type="text" name="cccardnumber" id="cccardnumber" maxlength="20"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="form-control @Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="form-control @Model.IsErr("cccardnumber")" autocomplete="cc-csc" />
         </div>
     </div>
     <div class="form-group row">

--- a/DevSamples/MyViewSet/Portals/_default/HotcakesViews/SocialSpokes/Views/Checkout/_CreditCardInput.cshtml
+++ b/DevSamples/MyViewSet/Portals/_default/HotcakesViews/SocialSpokes/Views/Checkout/_CreditCardInput.cshtml
@@ -58,7 +58,7 @@
         <input type="text" name="cccardnumber" id="cccardnumber" size="20" maxlength="20"
                 tabindex="501"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="@Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="@Model.IsErr("cccardnumber")" autocomplete="cc-csc" />
 
     </div>
     <div class="dnnFormItem">

--- a/Website/Portals/_default/HotcakesViews/Bootstrap4/Views/Checkout/_CreditCardInput.cshtml
+++ b/Website/Portals/_default/HotcakesViews/Bootstrap4/Views/Checkout/_CreditCardInput.cshtml
@@ -60,7 +60,7 @@
         <div class="col-sm-6 offset-sm-0">
             <input type="text" name="cccardnumber" id="cccardnumber" maxlength="20"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="form-control @Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="form-control @Model.IsErr("cccardnumber")" autocomplete="cc-csc" />
         </div>
     </div>
     <div class="form-group row">

--- a/Website/Portals/_default/HotcakesViews/Porto5/Views/Checkout/_CreditCardInput.cshtml
+++ b/Website/Portals/_default/HotcakesViews/Porto5/Views/Checkout/_CreditCardInput.cshtml
@@ -60,7 +60,7 @@
         <div class="col-sm-6 offset-sm-0">
             <input type="text" name="cccardnumber" id="cccardnumber" maxlength="20"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="form-control @Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="form-control @Model.IsErr("cccardnumber")" autocomplete="cc-csc" />
         </div>
     </div>
     <div class="form-group row">

--- a/Website/Portals/_default/HotcakesViews/SocialSpokes/Views/Checkout/_CreditCardInput.cshtml
+++ b/Website/Portals/_default/HotcakesViews/SocialSpokes/Views/Checkout/_CreditCardInput.cshtml
@@ -58,7 +58,7 @@
         <input type="text" name="cccardnumber" id="cccardnumber" size="20" maxlength="20"
                 tabindex="501"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="@Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="@Model.IsErr("cccardnumber")" autocomplete="cc-csc" />
 
     </div>
     <div class="dnnFormItem">

--- a/Website/Portals/_default/HotcakesViews/_default-Legacy/Views/Checkout/_CreditCardInput.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default-Legacy/Views/Checkout/_CreditCardInput.cshtml
@@ -58,7 +58,7 @@
         <input type="text" name="cccardnumber" id="cccardnumber" size="20" maxlength="20"
                 tabindex="501"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="@Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="@Model.IsErr("cccardnumber")" autocomplete="cc-csc" />
 
     </div>
     <div class="dnnFormItem">

--- a/Website/Portals/_default/HotcakesViews/_default/Views/Checkout/_CreditCardInput.cshtml
+++ b/Website/Portals/_default/HotcakesViews/_default/Views/Checkout/_CreditCardInput.cshtml
@@ -58,9 +58,9 @@
     <div class="form-group dnnFormRequired">
         <label class="col-sm-4 control-label" for="cccardnumber">@Localization.GetString("CardNumber"):</label>
         <div class="col-sm-offset-0 col-sm-6">
-            <input type="text" name="cccardnumber" id="cccardnumber" maxlength="20"
+            <input type="text" name="cccardnumber" id="cccardnumber" maxlength="20" autocomplete="cc-csc"
                 value="@Model.PaymentViewModel.DataCreditCard.CardNumber"                    
-                class="form-control @Model.IsErr("cccardnumber")" autocomplete="off" />
+                class="form-control @Model.IsErr("cccardnumber")" />
         </div>
     </div>
     <div class="form-group">


### PR DESCRIPTION
Update the autocomplete property for the card number input field to prevent browsers from displaying the save popup