### PR TITLE
Updated the Regex method. Issue #421 Fixed 

### DIFF
--- a/Libraries/Hotcakes.Web/Validation/ValidationHelper.cs
+++ b/Libraries/Hotcakes.Web/Validation/ValidationHelper.cs
@@ -34,7 +34,7 @@ namespace Hotcakes.Web.Validation
     public class ValidationHelper
     {
         public const string EmailValidationRegex = 
-                @"^(?("")("".+?(?<!\\)""@)|(([0-9a-z]((\.(?!\.))|[-!#\$%&'\*\+/=\?\^`\{\}\|~\w])*)(?<=[0-9a-z])@))" +
+                @"^(?("")("".+?(?<!\\)""@)|(([0-9a-z_]((\.(?!\.))|[-!#\$%&'\*\+/=\?\^`\{\}\|~\w])*)(?<=[0-9a-z_])@))" +
                 @"(?(\[)(\[(\d{1,3}\.){3}\d{1,3}\])|(([0-9a-z][-\w]*[0-9a-z]*\.)+[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))$";
 
         public static void Required(string errorMessage, string propertyValue, List<RuleViolation> violations,


### PR DESCRIPTION
Updated the Regex method that validates the email address when performing the Checkout, allowing the address to contain the underscore character in the address. Only allowed in the part of the email before the @domain... The Regex method that DNN uses when validating the email record allows this character. #421