### PR TITLE
Add the ShippingCharge property as a DataMember

### DIFF
--- a/Libraries/Hotcakes.CommerceDTO/v1/Orders/LineItemDTO.cs
+++ b/Libraries/Hotcakes.CommerceDTO/v1/Orders/LineItemDTO.cs
@@ -206,6 +206,7 @@ namespace Hotcakes.CommerceDTO.v1.Orders
         /// <value>
         ///     The shipping charge.
         /// </value>
+        [DataMember]
         public ShippingChargeTypeDTO ShippingCharge { get; set; }
 
         /// <summary>


### PR DESCRIPTION
This fixes #426 by adding the ```[DataMember]``` Attribute to the ```ShippingCharge``` Property on the LineItemDTO object.