### PR TITLE
Update HCC to use MSBuild Version=15.1.0.0 & C# 10.0

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
 	<PropertyGroup>
-		<LangVersion>C# 7.0</LangVersion>
+		<LangVersion>C# 10.0</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-"%programfiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" build.proj /nodeReuse:false /fileLogger /fileLoggerParameters:LogFile=MSBuildLog.txt
+"%programfiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" build.proj /nodeReuse:false /fileLogger /fileLoggerParameters:LogFile=MSBuildLog.txt


### PR DESCRIPTION
Modifying the Build.proj file and declaring C# 10.0 as the language.
Modify the build.bat file and change the MSBuild reference to the one found in VS2022.