### PR TITLE
Hcc resolve dll version warnings

### DIFF
--- a/Libraries/Hotcakes.Commerce.Dnn/App.Config
+++ b/Libraries/Hotcakes.Commerce.Dnn/App.Config
@@ -37,15 +37,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Website/DesktopModules/Hotcakes/Hotcakes.Modules.csproj
+++ b/Website/DesktopModules/Hotcakes/Hotcakes.Modules.csproj
@@ -156,7 +156,7 @@
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.AspNet.Mvc.5.1.1\lib\net45\System.Web.Mvc.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.Mvc.5.1.0\lib\net45\System.Web.Mvc.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Drawing" />

--- a/Website/DesktopModules/Hotcakes/packages.config
+++ b/Website/DesktopModules/Hotcakes/packages.config
@@ -13,4 +13,5 @@
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net451" developmentDependency="true" />
   <package id="PayPalCheckoutSdk" version="1.0.4" targetFramework="net472" />
   <package id="PayPalHttp" version="1.0.1" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Mvc" version="5.1.0" targetFramework="net472" />
 </packages>

--- a/Website/DesktopModules/Hotcakes/web.config
+++ b/Website/DesktopModules/Hotcakes/web.config
@@ -6,10 +6,10 @@
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
-			</dependentAssembly>
+    <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
+      </dependentAssembly>	
 			<dependentAssembly>
 				<assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />


### PR DESCRIPTION
The PR aims to correct all the conflicts that exist between the different versions of assembly references.

>System.Web.Mvc - v4.0.0.0, v5.1.0.0, v5.2.3.0.
>NewtonSoft.Json - v7.0.0.0, v10.0.0.0.

Changes made
___________________________________________________________________________________________________________________________________

- Update hotcakes-commerce-core\Website\DesktopModules\Hotcakes\web.config
- Update hotcakes-commerce-core\Website\DesktopModules\Hotcakes\packages.config
- Update hotcakes-commerce-core\Website\DesktopModules\Hotcakes\Hotcakes.Modules.csproj
- Update hotcakes-commerce-core\Libraries\Hotcakes.Commerce.Dnn\App.Config

Close #333