### PR TITLE
SI: Updating rgProducts before deleting

### DIFF
--- a/Website/DesktopModules/Hotcakes/ProductGrid/Settings.ascx.cs
+++ b/Website/DesktopModules/Hotcakes/ProductGrid/Settings.ascx.cs
@@ -188,6 +188,7 @@ namespace Hotcakes.Modules.ProductGrid
         protected void rgProducts_OnDeleteCommand(object sender, GridViewDeleteEventArgs e)
         {
             var bvinsList = GetProductBvins();
+            LoadItems(GetProducts(bvinsList));
             var key = (int)rgProducts.DataKeys[e.RowIndex].Value;
             bvinsList.Remove(key);
             SaveItems(bvinsList);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #474 

## Description
The problem was caused by data inconsistency between the dictionary containing the products loaded form the setting and the information stored inside of the grid view object. I solve it by adding a extra call to the LoadItems method to force the grid to update before the product is deleted.

## How Has This Been Tested?
Locally in my development environment

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.