### PR TITLE
Fix Issues 479 INVALID_PARAMETER_SYNTAX PayPal Payments Pro

### DIFF
--- a/Libraries/Hotcakes.PaypalWebServices/RestPaypalApi.cs
+++ b/Libraries/Hotcakes.PaypalWebServices/RestPaypalApi.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using PayPalCheckoutSdk.Core;
 using PayPalCheckoutSdk.Orders;
@@ -207,23 +208,23 @@ namespace Hotcakes.PaypalWebServices
                             AmountWithBreakdown = new AmountWithBreakdown
                             {
                                 CurrencyCode = currencyCodeType,
-                                Value = orderTotal,
+                                Value = formatAmount(orderTotal),
                                 AmountBreakdown = new AmountBreakdown
                                 {
                                     ItemTotal = new Money
                                     {
                                         CurrencyCode = currencyCodeType,
-                                        Value = itemsTotal
+                                        Value = formatAmount(itemsTotal)
                                     },
                                     Shipping = new Money
                                     {
                                         CurrencyCode = currencyCodeType,
-                                        Value = shippingTotal
+                                        Value = formatAmount(shippingTotal)
                                     },
                                     TaxTotal = new Money
                                     {
                                         CurrencyCode = currencyCodeType,
-                                        Value = taxTotal
+                                        Value = formatAmount(taxTotal)
                                     },
                                 }
                             },
@@ -282,18 +283,18 @@ namespace Hotcakes.PaypalWebServices
                         AmountWithBreakdown = new AmountWithBreakdown()
                         {
                             CurrencyCode = currencyCodeType,
-                            Value = orderTotal,
+                            Value = formatAmount(orderTotal),
                             AmountBreakdown = new AmountBreakdown()
                             {
                                 ItemTotal = new Money
                                 {
                                     CurrencyCode = currencyCodeType,
-                                    Value = itemsTotal
+                                    Value = formatAmount(itemsTotal)
                                 },
                                 TaxTotal = new Money
                                 {
                                     CurrencyCode = currencyCodeType,
-                                    Value = taxTotal
+                                    Value = formatAmount(taxTotal)
                                 },
                             }
                         }
@@ -310,6 +311,10 @@ namespace Hotcakes.PaypalWebServices
             return response;
         }
 
+        private string formatAmount(string amount)
+        {
+            return Regex.Replace(amount, "[, ]", "");
+        }
 
         public async Task<HttpResponse> GetOrder(string orderId)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes # [479 SI: INVALID_PARAMETER_SYNTAX PayPal Payments Pro](https://github.com/HotcakesCommerce/hotcakes-commerce-core/issues/479)

## Description
<!--- Describe your changes in detail -->
To solve the issue, add a method called formatAmount to cleanse (remove comma or space separators from) the order amounts before they are sent to the PayPal API.  Since that API doesn't accept values with separators such as commas or spaces.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
To test that the update fixed the issue, I created a clean DNN solution in version 09.13.00, compiled it, and generated a Hotcakes installer with the applied changes. Then, I conducted the initial store setup. I added a product with an amount greater than 999.00, specifically 1200.00.

Afterwards, I configured the payment methods, choosing PayPal, and updated the Sandbox Mode settings by entering the API Client Id and API Secret. Following that, I placed an order for the product priced above 999.00 (1200.00), and everything went smoothly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.