### PR TITLE
Fix PayPal CheckOut Error

### DIFF
--- a/Libraries/Hotcakes.PaypalWebServices/RestPaypalApi.cs
+++ b/Libraries/Hotcakes.PaypalWebServices/RestPaypalApi.cs
@@ -121,13 +121,13 @@ namespace Hotcakes.PaypalWebServices
                         AmountWithBreakdown = new AmountWithBreakdown
                         {
                             CurrencyCode = storeCurrency,
-                            Value = paymentAmount,
+                            Value = formatAmount(paymentAmount),
                             AmountBreakdown = new AmountBreakdown
                             {
                                 ItemTotal = new Money
                                 {
                                     CurrencyCode = storeCurrency,
-                                    Value = paymentAmount
+                                    Value = formatAmount(paymentAmount)
                                 },
                                 
                             }
@@ -351,7 +351,7 @@ namespace Hotcakes.PaypalWebServices
             {
                 Amount = new PayPalCheckoutSdk.Payments.Money()
                 {
-                    Value = value,
+                    Value = formatAmount(value),
                     CurrencyCode = currencyId
                 },
                 InvoiceId = invoiceId,
@@ -375,7 +375,7 @@ namespace Hotcakes.PaypalWebServices
             {
                 Amount = new PayPalCheckoutSdk.Payments.Money()
                 {
-                    Value = amount,
+                    Value = formatAmount(amount),
                     CurrencyCode = storeCurrency
                 }
             };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes # [Issues 484](https://github.com/HotcakesCommerce/hotcakes-commerce-core/issues/484)

## Description
<!--- Describe your changes in detail -->
The `formatAmount `method was applied to the amounts within the `doDirectCheckout`, `CaptureAuthorizedOrder`, and `CapturesRefund `methods in `RestPaypalApi` service  to adjust the currency format according to PayPal API requirements.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The HCC module was installed with the changes made, providing a clean DNN solution. The PayPal payment method was set up, and multiple tests were conducted to ensure that everything worked correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.