### PR TITLE
Check Store ID when Checking for Duplicate Variants

### DIFF
--- a/Libraries/Hotcakes.Commerce/Catalog/VariantRepository.cs
+++ b/Libraries/Hotcakes.Commerce/Catalog/VariantRepository.cs
@@ -128,13 +128,14 @@ namespace Hotcakes.Commerce.Catalog
 
         public bool IsSkuExist(string sku, Guid? excludeProductId = null)
         {
+            var storeId = Context.CurrentStore.Id;
             sku = sku.ToLower();
             using (var s = CreateReadStrategy())
             {
                 var q = excludeProductId.HasValue
                     ? s.GetQuery().Where(i => i.ProductId != excludeProductId)
                     : s.GetQuery();
-                return q.Any(i => i.Sku.ToLower() == sku);
+                return q.Where(y => y.StoreId == storeId).Any(i => i.Sku.ToLower() == sku);
             }
         }
 


### PR DESCRIPTION
When multiple stores exist, and you attempt to add a variant to a product, it is not currently filtered by StoreId. It gives an error message about the SKU already existing even though the SKU doesn't exist in the current store. 

This adds a stored check based on the current context.

## Related to Issue
No issue currently exists

## Description
Gets the current store id from the context and filters what variants we are looking for by the store id.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.