### PR TITLE
Bugfix/daterangepicker enddate logic

### DIFF
--- a/Website/DesktopModules/Hotcakes/Core/Admin/Controls/DateRangePicker.ascx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Controls/DateRangePicker.ascx.cs
@@ -112,7 +112,7 @@ namespace Hotcakes.Modules.Core.Admin.Controls
             {
                 if (RangeType == DateRangeType.Custom)
                 {
-                    var date = DateTime.Parse(radStartDate.Text.Trim());
+                    var date = DateTime.Parse(radEndDate.Text.Trim());
                     return date.MaxOutTime();
                 }
                 _range.RangeType = RangeType;
@@ -210,7 +210,7 @@ namespace Hotcakes.Modules.Core.Admin.Controls
             DateTime result;
             if (RangeType == DateRangeType.Custom)
             {
-                var date = DateTime.Parse(radStartDate.Text.Trim());
+                var date = DateTime.Parse(radEndDate.Text.Trim());
                 result = date.MaxOutTime();
             }
             else

--- a/Website/DesktopModules/Hotcakes/Providers/DataProviders/SqlDataProvider/03.09.00.SqlDataProvider
+++ b/Website/DesktopModules/Hotcakes/Providers/DataProviders/SqlDataProvider/03.09.00.SqlDataProvider
@@ -76,7 +76,7 @@ ALTER TABLE {databaseOwner}[{objectQualifier}hcc_Product] ADD
 END
 GO
 
-IF NOT EXISTS( SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{objectQualifier}hcc_Product' AND  COLUMN_NAME = 'IsUpchargeAllowed')
+IF NOT EXISTS( SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{objectQualifier}hcc_LineItem' AND  COLUMN_NAME = 'IsUpchargeAllowed')
 BEGIN
 ALTER TABLE {databaseOwner}[{objectQualifier}hcc_LineItem] ADD
 	[IsUpchargeAllowed] bit NOT NULL CONSTRAINT [DF_{objectQualifier}hcc_LineItem_IsUpchargeAllowed] DEFAULT 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #524 

## Description
<!--- Describe your changes in detail -->
This PR addresses the following issues:

- **DateRangePicker logic**: Fixed the `EndDate `method to properly parse and handle start and end dates, ensuring that the report functionality works as expected.
- **SQL column check**: Updated the **03.09.00.SqlDataProvider** script to correctly verify the existence of the `IsUpchargeAllowed `column in the `hcc_LineItem `table instead of the `hcc_Product `table.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Reproduced the original error in a local development environment.
- Applied fixes and verified that the DateRangePicker component correctly handles start and end dates during backend communication.
- Validated the SQL script changes to ensure the column check is executed properly without introducing additional errors.
- Conducted regression tests to ensure no other functionalities were affected.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/890df155-f3af-4f00-a183-801292607bb3)
![image](https://github.com/user-attachments/assets/228039e1-35f8-4bee-937f-0fc255864b5b)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.