### PR TITLE
Fix Category Drilldown View to respect Inventory Mode settings

### DIFF
--- a/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Products_Edit_Inventory.aspx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Products_Edit_Inventory.aspx.cs
@@ -29,6 +29,7 @@ using System.Web.UI.WebControls;
 using Hotcakes.Commerce.Catalog;
 using Hotcakes.Commerce.Membership;
 using Hotcakes.Modules.Core.Admin.AppCode;
+using Hotcakes.Commerce;
 
 namespace Hotcakes.Modules.Core.Admin.Catalog
 {
@@ -101,6 +102,7 @@ namespace Hotcakes.Modules.Core.Admin.Catalog
         {
             if (Save())
             {
+                CacheManager.ClearForStore(HccApp.CurrentStore.Id);
                 ucMessageBox.ShowOk("Changes Saved!");
             }
             LoadInventory();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #510 

## Description
<!--- Describe your changes in detail -->
This fix addresses an issue where products set to the inventory mode "When Out of Stock, Show but Don't Allow Purchases" disappear from the Category Drilldown view after clearing the HCC cache.  
The implemented solution automatically clears the store cache after saving changes to the inventory, ensuring that the changes are reflected correctly in the view.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in DNN 09.13.06 and HCC 03.09.00

## Screenshots (if appropriate):
https://app.screencast.com/26FO0pcWlSpQL

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.