### PR TITLE
Fixes incorrect date format in HC Admin "Reports" custom date range pickers

### DIFF
--- a/Website/DesktopModules/Hotcakes/Core/Admin/Controls/DateRangePicker.ascx
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Controls/DateRangePicker.ascx
@@ -31,12 +31,23 @@
         <asp:LinkButton ID="btnShow" CssClass="hcButton hcDatePickerButton" resourcekey="Show" runat="server" />
     </div>
     <script type="text/javascript">
-        $(function()
-        {
+        $(function () {
+            var dateFormat = "<%=CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern %>";
+
+            // Convert the .NET date format to flatpickr date format
+            var flatpickrDateFormat = dateFormat
+                .replace(/d{1,2}/g, "d")
+                .replace(/M{1,2}/g, "m")
+                .replace(/y{2,4}/g, "Y");
+
             $(".hcDateRangeTextBox").flatpickr({
-                dateFormat: "m/d/Y",
+                dateFormat: flatpickrDateFormat,
                 minDate: new Date(2013, 1, 1),
-                maxDate: "today"
+                maxDate: "today",
+                onChange: function (selectedDates, dateStr, instance) {
+                    var formattedDate = instance.formatDate(selectedDates[0], flatpickrDateFormat);
+                    $(instance.input).val(formattedDate);
+                }
             });
         });
     </script>

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Controls/DateRangePicker.ascx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Controls/DateRangePicker.ascx.cs
@@ -1,30 +1,5 @@
-#region License
-
-// Distributed under the MIT License
-// ============================================================
-// Copyright (c) 2019 Hotcakes Commerce, LLC
-// Copyright (c) 2020-2023 Upendo Ventures, LLC
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-// and associated documentation files (the "Software"), to deal in the Software without restriction, 
-// including without limitation the rights to use, copy, modify, merge, publish, distribute, 
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is 
-// furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or 
-// substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-// THE SOFTWARE.
-
-#endregion
-
 using System;
+using System.Globalization;
 using Hotcakes.Commerce;
 using Hotcakes.Commerce.Utilities;
 using Hotcakes.Modules.Core.Admin.AppCode;
@@ -32,25 +7,16 @@ using Hotcakes.Web;
 
 namespace Hotcakes.Modules.Core.Admin.Controls
 {
-    partial class DateRangePicker : HccUserControl
+    public partial class DateRangePicker : HccUserControl
     {
-        private const string DATEFORMAT = "MM/dd/yyyy";
-
-        #region Fields
-
+        private string DateFormat => CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
         private readonly DateRange _range = new DateRange();
 
-        public class RangeTypeChangedEventArgs : EventArgs
-        {
-        }
+        public class RangeTypeChangedEventArgs : EventArgs { }
 
         public delegate void RangeTypeChangedDelegate(object sender, RangeTypeChangedEventArgs e);
 
         public event RangeTypeChangedDelegate RangeTypeChanged;
-
-        #endregion
-
-        #region Properties
 
         public string FormItemCssClass { get; set; }
 
@@ -74,12 +40,12 @@ namespace Hotcakes.Modules.Core.Admin.Controls
 
         public DateRangeType RangeType
         {
-            get { return (DateRangeType) int.Parse(lstRangeType.SelectedValue); }
+            get { return (DateRangeType)int.Parse(lstRangeType.SelectedValue); }
             set
             {
-                if (lstRangeType.Items.FindByValue(((int) value).ToString()) != null)
+                if (lstRangeType.Items.FindByValue(((int)value).ToString()) != null)
                 {
-                    lstRangeType.SelectedValue = ((int) value).ToString();
+                    lstRangeType.SelectedValue = ((int)value).ToString();
                 }
             }
         }
@@ -90,7 +56,7 @@ namespace Hotcakes.Modules.Core.Admin.Controls
             {
                 if (RangeType == DateRangeType.Custom)
                 {
-                    var date = DateTime.Parse(radStartDate.Text.Trim());
+                    var date = DateTime.Parse(radStartDate.Text.Trim(), CultureInfo.CurrentCulture);
                     return date.ZeroOutTime();
                 }
                 _range.RangeType = RangeType;
@@ -101,7 +67,7 @@ namespace Hotcakes.Modules.Core.Admin.Controls
             }
             set
             {
-                radStartDate.Text = value.ToString(DATEFORMAT);
+                radStartDate.Text = value.ToString(DateFormat, CultureInfo.CurrentCulture);
                 RangeType = DateRangeType.Custom;
             }
         }
@@ -112,7 +78,7 @@ namespace Hotcakes.Modules.Core.Admin.Controls
             {
                 if (RangeType == DateRangeType.Custom)
                 {
-                    var date = DateTime.Parse(radEndDate.Text.Trim());
+                    var date = DateTime.Parse(radEndDate.Text.Trim(), CultureInfo.CurrentCulture);
                     return date.MaxOutTime();
                 }
                 _range.RangeType = RangeType;
@@ -122,14 +88,10 @@ namespace Hotcakes.Modules.Core.Admin.Controls
             }
             set
             {
-                radEndDate.Text = value.ToString(DATEFORMAT);
+                radEndDate.Text = value.ToString(DateFormat, CultureInfo.CurrentCulture);
                 RangeType = DateRangeType.Custom;
             }
         }
-
-        #endregion
-
-        #region Event Handlers
 
         public DateRangePicker()
         {
@@ -154,18 +116,12 @@ namespace Hotcakes.Modules.Core.Admin.Controls
 
         protected void btnShow_Click(object sender, EventArgs e)
         {
-            if (RangeTypeChanged != null)
-            {
-                RangeTypeChanged(this, new RangeTypeChangedEventArgs());
-            }
+            RangeTypeChanged?.Invoke(this, new RangeTypeChangedEventArgs());
         }
 
         protected void lstRangeType_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (RangeTypeChanged != null)
-            {
-                RangeTypeChanged(this, new RangeTypeChangedEventArgs());
-            }
+            RangeTypeChanged?.Invoke(this, new RangeTypeChangedEventArgs());
         }
 
         protected override void OnPreRender(EventArgs e)
@@ -174,16 +130,12 @@ namespace Hotcakes.Modules.Core.Admin.Controls
 
             if (RangeType != DateRangeType.Custom)
             {
-                radStartDate.Text = StartDate.ToString(DATEFORMAT);
-                radEndDate.Text = EndDate.ToString(DATEFORMAT);
+                radStartDate.Text = StartDate.ToString(DateFormat, CultureInfo.CurrentCulture);
+                radEndDate.Text = EndDate.ToString(DateFormat, CultureInfo.CurrentCulture);
             }
 
-            pnlCustom.Visible = lstRangeType.SelectedValue == ((int) DateRangeType.Custom).ToString();
+            pnlCustom.Visible = lstRangeType.SelectedValue == ((int)DateRangeType.Custom).ToString();
         }
-
-        #endregion
-
-        #region Public Methods
 
         public DateTime GetStartDateUtc(HotcakesApplication hccApp)
         {
@@ -191,13 +143,12 @@ namespace Hotcakes.Modules.Core.Admin.Controls
 
             if (RangeType == DateRangeType.Custom)
             {
-                var date = DateTime.Parse(radStartDate.Text.Trim());
+                var date = DateTime.Parse(radStartDate.Text.Trim(), CultureInfo.CurrentCulture);
                 result = date.ZeroOutTime();
             }
             else
             {
                 _range.RangeType = RangeType;
-                ;
                 _range.CalculateDatesFromType(DateHelper.ConvertUtcToStoreTime(hccApp));
                 result = _range.StartDate;
             }
@@ -210,7 +161,7 @@ namespace Hotcakes.Modules.Core.Admin.Controls
             DateTime result;
             if (RangeType == DateRangeType.Custom)
             {
-                var date = DateTime.Parse(radEndDate.Text.Trim());
+                var date = DateTime.Parse(radEndDate.Text.Trim(), CultureInfo.CurrentCulture);
                 result = date.MaxOutTime();
             }
             else
@@ -222,7 +173,5 @@ namespace Hotcakes.Modules.Core.Admin.Controls
 
             return DateHelper.ConvertStoreTimeToUtc(hccApp, result);
         }
-
-        #endregion
     }
 }

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Controls/DateRangePicker.ascx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Controls/DateRangePicker.ascx.cs
@@ -1,3 +1,29 @@
+#region License
+
+// Distributed under the MIT License
+// ============================================================
+// Copyright (c) 2019 Hotcakes Commerce, LLC
+// Copyright (c) 2020-2023 Upendo Ventures, LLC
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+// and associated documentation files (the "Software"), to deal in the Software without restriction, 
+// including without limitation the rights to use, copy, modify, merge, publish, distribute, 
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is 
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or 
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+// THE SOFTWARE.
+
+#endregion
+
 using System;
 using System.Globalization;
 using Hotcakes.Commerce;
@@ -11,13 +37,16 @@ namespace Hotcakes.Modules.Core.Admin.Controls
     {
         private string DateFormat => CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
         private readonly DateRange _range = new DateRange();
-
+        #region Fields
         public class RangeTypeChangedEventArgs : EventArgs { }
 
         public delegate void RangeTypeChangedDelegate(object sender, RangeTypeChangedEventArgs e);
 
         public event RangeTypeChangedDelegate RangeTypeChanged;
 
+        #endregion
+
+        #region Properties
         public string FormItemCssClass { get; set; }
 
         public string LabelText
@@ -92,7 +121,9 @@ namespace Hotcakes.Modules.Core.Admin.Controls
                 RangeType = DateRangeType.Custom;
             }
         }
+        #endregion
 
+        #region Event Handlers
         public DateRangePicker()
         {
             FormItemCssClass = "hcFormItemHor";
@@ -137,6 +168,9 @@ namespace Hotcakes.Modules.Core.Admin.Controls
             pnlCustom.Visible = lstRangeType.SelectedValue == ((int)DateRangeType.Custom).ToString();
         }
 
+        #endregion
+
+        #region Public Methods
         public DateTime GetStartDateUtc(HotcakesApplication hccApp)
         {
             DateTime result;
@@ -173,5 +207,7 @@ namespace Hotcakes.Modules.Core.Admin.Controls
 
             return DateHelper.ConvertStoreTimeToUtc(hccApp, result);
         }
+
+        #endregion
     }
 }

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Reports/Summary Report/View.aspx
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Reports/Summary Report/View.aspx
@@ -1,12 +1,10 @@
-﻿<%@ Page Language="C#" MasterPageFile="../../AdminNav.master" AutoEventWireup="true" Inherits="Hotcakes.Modules.Core.Admin.Reports.Summary_Report.View" Title="Untitled Page" CodeBehind="View.aspx.cs" %>
+﻿<%@ Page Language="C#" MasterPageFile="../../AdminNav.master" AutoEventWireup="true" Inherits="Hotcakes.Modules.Core.Admin.Reports.Summary_Report.View" Title="Untitled Page" CodeBehind="View.aspx.cs" Culture="auto" UICulture="auto" %>
 
 <%@ Register Src="../../Controls/MessageBox.ascx" TagName="MessageBox" TagPrefix="hcc" %>
 <%@ Register Src="../../Controls/DateRangePicker.ascx" TagName="DateRangePicker" TagPrefix="hcc" %>
 
 <asp:Content ContentPlaceHolderID="MainContent" runat="Server">
-    
     <div class="hcReport">
-        
         <h1><%=PageTitle %></h1>
         <hcc:MessageBox ID="ucMessageBox" runat="server" />
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #300 

## Description
<!--- Describe your changes in detail -->
This pull request updates the date pickers in HC Admin Reports → Custom Date Range to dynamically use the correct date format based on CurrentCulture. Previously, date pickers were hardcoded to en-US (MM/dd/yyyy), which caused inconsistencies and errors when using the en-GB locale (dd/MM/yyyy).

- Now, flatpickr dynamically adjusts to the date format based on CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.
- The .NET date format is automatically converted to flatpickr-compatible format.
- Ensures that all affected reports use the correct localized format without requiring manual configuration.
- Updated C# backend to ensure consistent parsing of date values based on the current culture

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested locally and confirmed correct behavior in en-GB (dd/MM/yyyy).
and verified that en-US users still see MM/dd/yyyy as expected. And I tested the functionality on all reports

## Screenshots (if appropriate):
Previus error
![image](https://github.com/user-attachments/assets/6aa02b58-06e5-48f4-88d5-db55f46035c2)

Fixed
![image](https://github.com/user-attachments/assets/1fdd281d-6540-4f94-9b9d-486c8d1ec673)
![image](https://github.com/user-attachments/assets/fb9154d3-d5c1-4a5b-9a5c-1ed7b87d5dbf)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.