### PR TITLE
Product type property deleting issue

### DIFF
--- a/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/App_LocalResources/ProductTypeProperties.aspx.resx
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/App_LocalResources/ProductTypeProperties.aspx.resx
@@ -132,6 +132,9 @@
   <data name="CreateError.Text" xml:space="preserve">
     <value>Error while attempting to create new property. Please check the event log.</value>
   </data>
+  <data name="DeleteErrorPropertyAssigned.Text" xml:space="preserve">
+    <value>This property is assigned to a product and cannot be deleted.</value>
+  </data>
   <data name="DisplayName.HeaderText" xml:space="preserve">
     <value>Display Name</value>
   </data>

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/ProductTypeProperties.aspx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/ProductTypeProperties.aspx.cs
@@ -90,7 +90,16 @@ namespace Hotcakes.Modules.Core.Admin.Catalog
 
         protected void dgList_DeleteCommand(object source, DataGridCommandEventArgs e)
         {
-            var deleteID = (long) dgList.DataKeys[e.Item.ItemIndex];
+            var deleteID = (long)dgList.DataKeys[e.Item.ItemIndex];
+
+            // Check if the property is assigned to any product type
+            var isPropertyAssigned = HccApp.CatalogServices.ProductTypesXProperties.Find(deleteID);
+            if (isPropertyAssigned != null)
+            {
+                msg.ShowError(Localization.GetString("DeleteErrorPropertyAssigned"));
+                return;
+            }
+
             HccApp.CatalogServices.ProductPropertiesDestroy(deleteID);
             LoadItems();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #187 

## Description
<!--- Describe your changes in detail -->
Added a change to the dgList_DeleteCommand method to ensure that when a product type property value is deleted, a reference check is performed, if this value is currently assigned to a product it does not allow deletion and displays an error message "This property is assigned to a product and cannot be deleted."

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested locally

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/ed15b069-004f-4920-9efc-7815106ce2e7)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.