### PR TITLE
Ensure Bangladesh is not enabled by default on upgrades

### DIFF
--- a/Website/DesktopModules/Hotcakes/Hotcakes.Modules.csproj
+++ b/Website/DesktopModules/Hotcakes/Hotcakes.Modules.csproj
@@ -3791,6 +3791,7 @@
     <Content Include="Providers\DataProviders\SqlDataProvider\03.09.00.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\03.09.01.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\03.09.02.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\03.09.03.SqlDataProvider" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/Website/DesktopModules/Hotcakes/Providers/DataProviders/SqlDataProvider/03.09.02.SqlDataProvider
+++ b/Website/DesktopModules/Hotcakes/Providers/DataProviders/SqlDataProvider/03.09.02.SqlDataProvider
@@ -76,3 +76,45 @@ VALUES
 ('a39d8f5a-cb8e-4c29-9d89-939dd6a1d15b', 'Tangail', 'BD-63'),
 ('a39d8f5a-cb8e-4c29-9d89-939dd6a1d15b', 'Thakurgaon', 'BD-64');
 GO
+
+-- Add BGD to DisabledCountryIso3Codes for all existing stores
+DECLARE @StoreId BIGINT;
+
+-- Cursor to iterate through all Store Ids
+DECLARE StoreCursor CURSOR FOR
+SELECT Id FROM dbo.[hcc_Stores];
+
+OPEN StoreCursor;
+
+FETCH NEXT FROM StoreCursor INTO @StoreId;
+
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    -- Check if the record exists for the current StoreId
+    IF EXISTS (SELECT 1 FROM dbo.[hcc_StoreSettings] WHERE SettingName = 'DisabledCountryIso3Codes' AND StoreId = @StoreId)
+    BEGIN
+        -- Update the existing record
+        UPDATE dbo.[hcc_StoreSettings]
+        SET SettingValue = 
+            CASE 
+                WHEN CHARINDEX('BGD', SettingValue) = 0 THEN SettingValue + ',BGD'
+                ELSE SettingValue
+            END
+        WHERE SettingName = 'DisabledCountryIso3Codes' AND StoreId = @StoreId;
+    END
+    ELSE
+    BEGIN
+        -- Insert a new record for the current StoreId
+        INSERT INTO dbo.[hcc_StoreSettings] (StoreId, SettingName, SettingValue)
+        VALUES (@StoreId, 'DisabledCountryIso3Codes', 'BGD');
+    END;
+
+    -- Fetch the next StoreId
+    FETCH NEXT FROM StoreCursor INTO @StoreId;
+END;
+
+-- Close and deallocate the cursor
+CLOSE StoreCursor;
+DEALLOCATE StoreCursor;
+
+GO

--- a/Website/DesktopModules/Hotcakes/Providers/DataProviders/SqlDataProvider/03.09.03.SqlDataProvider
+++ b/Website/DesktopModules/Hotcakes/Providers/DataProviders/SqlDataProvider/03.09.03.SqlDataProvider
@@ -1,0 +1,42 @@
+﻿/* Add BGD to DisabledCountryIso3Codes for all existing stores */
+
+DECLARE @StoreId BIGINT;
+
+-- Cursor to iterate through all Store Ids
+DECLARE StoreCursor CURSOR FOR
+SELECT Id FROM dbo.[hcc_Stores];
+
+OPEN StoreCursor;
+
+FETCH NEXT FROM StoreCursor INTO @StoreId;
+
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    -- Check if the record exists for the current StoreId
+    IF EXISTS (SELECT 1 FROM dbo.[hcc_StoreSettings] WHERE SettingName = 'DisabledCountryIso3Codes' AND StoreId = @StoreId)
+    BEGIN
+        -- Update the existing record
+        UPDATE dbo.[hcc_StoreSettings]
+        SET SettingValue = 
+            CASE 
+                WHEN CHARINDEX('BGD', SettingValue) = 0 THEN SettingValue + ',BGD'
+                ELSE SettingValue
+            END
+        WHERE SettingName = 'DisabledCountryIso3Codes' AND StoreId = @StoreId;
+    END
+    ELSE
+    BEGIN
+        -- Insert a new record for the current StoreId
+        INSERT INTO dbo.[hcc_StoreSettings] (StoreId, SettingName, SettingValue)
+        VALUES (@StoreId, 'DisabledCountryIso3Codes', 'BGD');
+    END;
+
+    -- Fetch the next StoreId
+    FETCH NEXT FROM StoreCursor INTO @StoreId;
+END;
+
+-- Close and deallocate the cursor
+CLOSE StoreCursor;
+DEALLOCATE StoreCursor;
+
+GO


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #533 

## Description
- Added a script to iterate through all stores in the `hcc_Stores` table.
- For each store:
  - If the `DisabledCountryIso3Codes` setting exists, `BGD` is appended to the `SettingValue` only if it is not already present.
  - If the `DisabledCountryIso3Codes` setting does not exist, a new record is created with `SettingValue = 'BGD'`.
- Ensured that Bangladesh remains disabled unless explicitly enabled by the user.

## How Has This Been Tested?
- Tested scenarios where:
  - The `DisabledCountryIso3Codes` setting already exists and includes `BGD`.
  - The `DisabledCountryIso3Codes` setting already exists but does not include `BGD`.
  - The `DisabledCountryIso3Codes` setting does not exist for a store.
- Confirmed that Bangladesh does not appear in the checkout process by default after upgrades.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/952ab0fa-2e65-4cdd-967f-e1f295084c27)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.