### PR TITLE
Ensure Proper Initialization of HccRequestContext and HotcakesApplication During Product Import

### DIFF
--- a/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Products_Import.aspx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Products_Import.aspx.cs
@@ -127,13 +127,24 @@ namespace Hotcakes.Modules.Core.Admin.Catalog
 			HccRequestContext.Current = conf.HccRequestContext;
 			DnnGlobal.SetPortalSettings(conf.DnnPortalSettings);
 			Factory.HttpContext = conf.HttpContext;
-			CultureSwitch.SetCulture(HccApp.CurrentStore, conf.DnnPortalSettings);
+
+            var hccRequestContext = new HccRequestContext
+            {
+                CurrentStore = conf.HccRequestContext.CurrentStore, 
+                MainContentCulture = System.Globalization.CultureInfo.CurrentCulture.Name,
+                FallbackContentCulture = "en-US",
+                CurrentAccount = conf.HccRequestContext.CurrentAccount,
+                RoutingContext = conf.HttpContext?.Request?.RequestContext,
+            };
+            HotcakesApplication hccApp = new HotcakesApplication(hccRequestContext);
+
+            CultureSwitch.SetCulture(hccApp.CurrentStore, conf.DnnPortalSettings);
 
 			var manager = new SessionManager(conf.Session);
 			manager.AdminProductImportLog = null;
 			manager.AdminProductImportProgress = 0;
 
-			var catImport = new CatalogImport(HccApp);
+			var catImport = new CatalogImport(hccApp);
 			catImport.UpdateExistingProducts = chkImportOverride.Checked;
 
             // added import path so version 2.xx knows where import images are stored


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #541 

## Description
This PR resolves an issue where products imported from Excel were incorrectly assigned StoreId = 0. The root cause was an incorrectly initialized HotcakesApplication instance, which did not contain the correct store context during the import process.

Changes Implemented:

- Properly initialized HccRequestContext with the necessary properties, including CurrentStore, MainContentCulture, FallbackContentCulture, etc.
- Used the updated HccRequestContext to initialize HotcakesApplication to ensure the correct store context is maintained.
- Ensured that the correct StoreId is used throughout the import process, preventing products from being incorrectly assigned to the default store (StoreId = 0).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Conducted import tests on two different portals/stores.
- Verified that products were correctly assigned to their respective stores during the import process.
- Confirmed that the issue where products were being assigned to StoreId = 0 no longer occurred.
- Ensured that the changes did not affect other parts of the import functionality.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/06c5e389-66f2-4181-94c2-ef4740f4445f)
![image](https://github.com/user-attachments/assets/5df95053-d97b-4b5c-b92f-97408de63538)
![image](https://github.com/user-attachments/assets/773df9b3-ad50-4512-9e1d-c9c300f45c68)
![image](https://github.com/user-attachments/assets/34461419-2e48-46a5-9246-739e75dd4753)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.