### PR TITLE
PayPal Setting City to State with Shipping Orders

### DIFF
--- a/Libraries/Hotcakes.Commerce/Accounts/StoreSettingsPayPal.cs
+++ b/Libraries/Hotcakes.Commerce/Accounts/StoreSettingsPayPal.cs
@@ -103,5 +103,11 @@ namespace Hotcakes.Commerce.Accounts
             get { return parent.GetProp("PayPalFastSignupEmail"); }
             set { parent.SetProp("PayPalFastSignupEmail", value); }
         }
+
+        public bool NoOrderTotalBreakdown
+        {
+            get { return parent.GetPropBool("PayPalNoTotalBreakdown"); }
+            set { parent.SetProp("PayPalNoTotalBreakdown", value); }
+        }
     }
 }

--- a/Libraries/Hotcakes.Commerce/BusinessRules/OrderTasks/StartPaypalExpressCheckout.cs
+++ b/Libraries/Hotcakes.Commerce/BusinessRules/OrderTasks/StartPaypalExpressCheckout.cs
@@ -60,6 +60,16 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
             {
                 try
                 {
+                    // Assign the order number for PayPal to show under the Invoice ID. If this is not done then PayPal wont show this orders number in the business UI.
+                    if (string.IsNullOrEmpty(context.Order.OrderNumber))
+                    {
+                        context.Order.OrderNumber = context.HccApp.OrderServices.GenerateNewOrderNumber(context.HccApp.CurrentRequestContext.CurrentStore.Id).ToString();
+                        Hotcakes.Commerce.Orders.OrderNote orderNote = new Hotcakes.Commerce.Orders.OrderNote();
+                        orderNote.IsPublic = false;
+                        orderNote.Note = "This order was assigned number " + context.Order.OrderNumber;
+                        context.Order.Notes.Add(orderNote);
+                    }
+
                     RestPayPalApi replacePayPal = Utilities.PaypalExpressUtilities.GetRestPaypalAPI(context.HccApp.CurrentStore);
 
                     string cartReturnUrl = HccUrlBuilder.RouteHccUrl(HccRoute.ThirdPartyPayment, null, Uri.UriSchemeHttps);
@@ -84,9 +94,9 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
                         context.Order.CustomProperties.Add("hcc", "ViaCheckout", "1");
                     }
 
-					
+					string invoiceNumber = (false == string.IsNullOrEmpty(context.Order.OrderNumber)) ? context.Order.OrderNumber : Guid.NewGuid().ToString();
 
-					PayPalHttp.HttpResponse expressResponse;
+                    PayPalHttp.HttpResponse expressResponse;
                     if (addressSupplied)
                     {
                         Contacts.Address address = context.Order.ShippingAddress;
@@ -117,6 +127,12 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
 							string shippingTotal = shippingTotalWithoutTax.ToString("N", CultureInfo.InvariantCulture);
 
 							string orderTotal = context.Order.TotalGrand.ToString("N", CultureInfo.InvariantCulture);
+                            context.Order.Notes.Add(new Orders.OrderNote
+                            {
+                                IsPublic = false,
+                                Note = "Sending to Paypal. Address Supplied = true.     Shipping Total: " + shippingTotal + "   Order Total:  " + orderTotal
+                            });
+
                             expressResponse = System.Threading.Tasks.Task.Run(() => replacePayPal.createOrder(
                                                     itemsTotal,
                                                     taxTotal,
@@ -134,7 +150,7 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
                                                     address.RegionBvin,
                                                     address.PostalCode,
                                                     address.Phone,
-                                                    context.Order.OrderNumber + Guid.NewGuid().ToString(),
+                                                    invoiceNumber,
                                                     isNonShipping)).GetAwaiter().GetResult(); 
                             if (expressResponse == null)
                             {
@@ -162,7 +178,12 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
 						}
 						string itemsTotal = itemsTotalWithoutTax.ToString("N", CultureInfo.InvariantCulture);
 						string orderTotal = context.Order.TotalOrderAfterDiscounts.ToString("N", CultureInfo.InvariantCulture);
-						expressResponse = System.Threading.Tasks.Task.Run(() => replacePayPal.createOrder(
+                        context.Order.Notes.Add(new Orders.OrderNote
+                        {
+                            IsPublic = false,
+                            Note = "Sending to Paypal. Address Supplied = false.     Shipping Total: " + context.Order.TotalShippingAfterDiscounts.ToString("N", CultureInfo.InvariantCulture) + "   Order Total:  " + orderTotal
+                        });
+                        expressResponse = System.Threading.Tasks.Task.Run(() => replacePayPal.createOrder(
                             itemsTotal,
                             taxTotal,
                             orderTotal,
@@ -170,7 +191,7 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
                             cartCancelUrl,
                             mode,
                             context.HccApp.CurrentStore.Settings.PayPal.Currency,
-                            context.Order.OrderNumber + Guid.NewGuid().ToString(),
+                            invoiceNumber,
                             isNonShipping)).GetAwaiter().GetResult();
                         
                         if (expressResponse == null)

--- a/Libraries/Hotcakes.Commerce/BusinessRules/OrderTasks/StartPaypalExpressCheckout.cs
+++ b/Libraries/Hotcakes.Commerce/BusinessRules/OrderTasks/StartPaypalExpressCheckout.cs
@@ -60,16 +60,6 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
             {
                 try
                 {
-                    // Assign the order number for PayPal to show under the Invoice ID. If this is not done then PayPal wont show this orders number in the business UI.
-                    if (string.IsNullOrEmpty(context.Order.OrderNumber))
-                    {
-                        context.Order.OrderNumber = context.HccApp.OrderServices.GenerateNewOrderNumber(context.HccApp.CurrentRequestContext.CurrentStore.Id).ToString();
-                        Hotcakes.Commerce.Orders.OrderNote orderNote = new Hotcakes.Commerce.Orders.OrderNote();
-                        orderNote.IsPublic = false;
-                        orderNote.Note = "This order was assigned number " + context.Order.OrderNumber;
-                        context.Order.Notes.Add(orderNote);
-                    }
-
                     RestPayPalApi replacePayPal = Utilities.PaypalExpressUtilities.GetRestPaypalAPI(context.HccApp.CurrentStore);
 
                     string cartReturnUrl = HccUrlBuilder.RouteHccUrl(HccRoute.ThirdPartyPayment, null, Uri.UriSchemeHttps);
@@ -86,6 +76,7 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
 
                     bool isNonShipping = !context.Order.HasShippingItems;
 
+                    bool skipBreakdownOfOrderTotals = context.HccApp.CurrentStore.Settings.PayPal.NoOrderTotalBreakdown;
                     bool addressSupplied = false;
                     if (context.Inputs["ViaCheckout"] != null
                         && context.Inputs["ViaCheckout"].Value == "1")
@@ -132,6 +123,14 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
                                 IsPublic = false,
                                 Note = "Sending to Paypal. Address Supplied = true.     Shipping Total: " + shippingTotal + "   Order Total:  " + orderTotal
                             });
+
+                            if(skipBreakdownOfOrderTotals)
+                            {
+                                // If breakdown of order totals is not required, we can send the total order amount directly
+                                itemsTotal = orderTotal;
+                                taxTotal = "0.00";
+                                shippingTotal = "0.00";
+                            }
 
                             expressResponse = System.Threading.Tasks.Task.Run(() => replacePayPal.createOrder(
                                                     itemsTotal,
@@ -183,6 +182,14 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
                             IsPublic = false,
                             Note = "Sending to Paypal. Address Supplied = false.     Shipping Total: " + context.Order.TotalShippingAfterDiscounts.ToString("N", CultureInfo.InvariantCulture) + "   Order Total:  " + orderTotal
                         });
+
+                        if (skipBreakdownOfOrderTotals)
+                        {
+                            // If breakdown of order totals is not required, we can send the total order amount directly
+                            itemsTotal = orderTotal;
+                            taxTotal = "0.00";
+                        }
+
                         expressResponse = System.Threading.Tasks.Task.Run(() => replacePayPal.createOrder(
                             itemsTotal,
                             taxTotal,

--- a/Libraries/Hotcakes.Commerce/BusinessRules/ThirdPartyCheckoutOrderTask.cs
+++ b/Libraries/Hotcakes.Commerce/BusinessRules/ThirdPartyCheckoutOrderTask.cs
@@ -38,6 +38,16 @@ namespace Hotcakes.Commerce.BusinessRules
             {
                 context.Order.CustomProperties.Add("hcc", "MethodId", PaymentMethodId);
 
+                // Assign the order number for PayPal or any third party payment to show under the Invoice ID. If this is not done then PayPal wont show this orders number in the business UI.
+                if (string.IsNullOrEmpty(context.Order.OrderNumber))
+                {
+                    context.Order.OrderNumber = context.HccApp.OrderServices.GenerateNewOrderNumber(context.HccApp.CurrentRequestContext.CurrentStore.Id).ToString();
+                    Hotcakes.Commerce.Orders.OrderNote orderNote = new Hotcakes.Commerce.Orders.OrderNote();
+                    orderNote.IsPublic = false;
+                    orderNote.Note = "This order was assigned number " + context.Order.OrderNumber;
+                    context.Order.Notes.Add(orderNote);
+                }
+
                 context.HccApp.OrderServices.Orders.Update(context.Order);
 
                 return ProcessCheckout(context);

--- a/Libraries/Hotcakes.Commerce/Catalog/CatalogImport.cs
+++ b/Libraries/Hotcakes.Commerce/Catalog/CatalogImport.cs
@@ -951,36 +951,37 @@ namespace Hotcakes.Commerce.Catalog
 				var isNew = opt == null;
                 var processedOptionItems = new List<string>();
 
+                var column = "E";
+                while (column.Length < 10)
+                {
+                    var choiceItem = GetCell(row, column);
+
+                    if (string.IsNullOrWhiteSpace(choiceItem))
+                    {
+                        break;
+                    }
+
+                    if (opt.OptionType == OptionTypes.Html)
+                    {
+                        opt.TextSettings.AddOrUpdate("html", choiceItem);
+                    }
+                    else
+                    {
+                        if (opt.Items.All(e => e.Name != choiceItem))
+                        {
+                            opt.AddItem(choiceItem);
+                        }
+                        processedOptionItems.Add(choiceItem);
+                    }
+
+                    column = GetNextColumn(column);
+                }
+
                 if (isNew)
 				{
                     opt = new Option {Name = choiceName, IsShared = shared};
                 
 				    opt.SetProcessor(optionType);
-                    var column = "E";
-				    while (column.Length < 10)
-				    {
-                        var choiceItem = GetCell(row, column);
-
-					    if (string.IsNullOrWhiteSpace(choiceItem))
-					    {
-						    break;
-					    }
-
-					    if (opt.OptionType == OptionTypes.Html)
-					    {
-						    opt.TextSettings.AddOrUpdate("html", choiceItem);
-					    }
-					    else
-					    {
-						    if (opt.Items.All(e => e.Name != choiceItem))
-						    {
-							    opt.AddItem(choiceItem);
-						    }
-						    processedOptionItems.Add(choiceItem);
-					    }
-
-					    column = GetNextColumn(column);
-				    }
 
                     _hccApp.CatalogServices.ProductOptions.Create(opt);
                     options = _hccApp.CatalogServices.ProductOptions.FindAll(0, int.MaxValue);

--- a/Libraries/Hotcakes.Commerce/Data/HccSimpleRepoBase.cs
+++ b/Libraries/Hotcakes.Commerce/Data/HccSimpleRepoBase.cs
@@ -290,6 +290,16 @@ namespace Hotcakes.Commerce.Data
             GetSubItems(model);
             return model;
         }
+        
+        protected virtual List<V> FindListPocoMainInstance(Func<IQueryable<T>, IQueryable<T>> processQuery)
+        {
+            using (var s = CreateStrategy())
+            {
+                var items = processQuery(s.GetQuery().AsNoTracking()).ToList();
+                return ListPoco(items);
+            }
+            ;
+        }
 
         protected virtual List<V> FindListPoco(Func<IQueryable<T>, IQueryable<T>> processQuery)
         {

--- a/Libraries/Hotcakes.Commerce/HccRequestContext.cs
+++ b/Libraries/Hotcakes.Commerce/HccRequestContext.cs
@@ -86,7 +86,8 @@ namespace Hotcakes.Commerce
             {
                 if (HttpContext.Current == null)
                 {
-                    _current = new HccRequestContext();
+                    if(_current == null)
+                        _current = new HccRequestContext();
                     return _current;
                 }
                 return (HccRequestContext) HttpContext.Current.Items[CONTEXT_KEY];

--- a/Libraries/Hotcakes.Commerce/Orders/OrderTransactionRepository.cs
+++ b/Libraries/Hotcakes.Commerce/Orders/OrderTransactionRepository.cs
@@ -170,7 +170,7 @@ namespace Hotcakes.Commerce.Orders
 		public List<OrderTransaction> FindForOrder(string orderId, ActionType byAction = ActionType.Unknown)
 		{
 			var orderGuid = DataTypeHelper.BvinToGuid(orderId);
-			return FindListPoco(q =>
+			return FindListPocoMainInstance(q =>
 			{
 				var query = q.Where(y => y.OrderId == orderGuid);
 				if (byAction != ActionType.Unknown)

--- a/Libraries/Hotcakes.PaypalWebServices/RestPaypalApi.cs
+++ b/Libraries/Hotcakes.PaypalWebServices/RestPaypalApi.cs
@@ -216,17 +216,7 @@ namespace Hotcakes.PaypalWebServices
                                     {
                                         CurrencyCode = currencyCodeType,
                                         Value = formatAmount(itemsTotal)
-                                    },
-                                    Shipping = new Money
-                                    {
-                                        CurrencyCode = currencyCodeType,
-                                        Value = formatAmount(shippingTotal)
-                                    },
-                                    TaxTotal = new Money
-                                    {
-                                        CurrencyCode = currencyCodeType,
-                                        Value = formatAmount(taxTotal)
-                                    },
+                                    }
                                 }
                             },
                             ShippingDetail = new ShippingDetail
@@ -248,6 +238,24 @@ namespace Hotcakes.PaypalWebServices
                         }
                     }
             };
+
+            if(!string.IsNullOrEmpty(shippingTotal))
+            {
+                order.PurchaseUnits[0].AmountWithBreakdown.AmountBreakdown.Shipping = new Money
+                {
+                    CurrencyCode = currencyCodeType,
+                    Value = formatAmount(shippingTotal)
+                };
+            }
+
+            if (!string.IsNullOrEmpty(taxTotal))
+            {
+                order.PurchaseUnits[0].AmountWithBreakdown.AmountBreakdown.TaxTotal = new Money
+                {
+                    CurrencyCode = currencyCodeType,
+                    Value = formatAmount(taxTotal)
+                };
+            }
 
             var request = new OrdersCreateRequest();
             request.Prefer(REQUEST_RETURN_TYPE);
@@ -291,17 +299,21 @@ namespace Hotcakes.PaypalWebServices
                                 {
                                     CurrencyCode = currencyCodeType,
                                     Value = formatAmount(itemsTotal)
-                                },
-                                TaxTotal = new Money
-                                {
-                                    CurrencyCode = currencyCodeType,
-                                    Value = formatAmount(taxTotal)
-                                },
+                                }
                             }
                         }
                     }
                 }
             };
+
+            if (!string.IsNullOrEmpty(taxTotal))
+            {
+                order.PurchaseUnits[0].AmountWithBreakdown.AmountBreakdown.TaxTotal = new Money
+                {
+                    CurrencyCode = currencyCodeType,
+                    Value = formatAmount(taxTotal)
+                };
+            }
 
             // Call API with your client and get a response for your call
             var request = new OrdersCreateRequest();

--- a/Libraries/Hotcakes.PaypalWebServices/RestPaypalApi.cs
+++ b/Libraries/Hotcakes.PaypalWebServices/RestPaypalApi.cs
@@ -216,6 +216,16 @@ namespace Hotcakes.PaypalWebServices
                                     {
                                         CurrencyCode = currencyCodeType,
                                         Value = formatAmount(itemsTotal)
+                                    },
+                                    Shipping = new Money
+                                    {
+                                        CurrencyCode = currencyCodeType,
+                                        Value = formatAmount(shippingTotal)
+                                    },
+                                    TaxTotal = new Money
+                                    {
+                                        CurrencyCode = currencyCodeType,
+                                        Value = formatAmount(taxTotal)
                                     }
                                 }
                             },
@@ -238,24 +248,6 @@ namespace Hotcakes.PaypalWebServices
                         }
                     }
             };
-
-            if(!string.IsNullOrEmpty(shippingTotal))
-            {
-                order.PurchaseUnits[0].AmountWithBreakdown.AmountBreakdown.Shipping = new Money
-                {
-                    CurrencyCode = currencyCodeType,
-                    Value = formatAmount(shippingTotal)
-                };
-            }
-
-            if (!string.IsNullOrEmpty(taxTotal))
-            {
-                order.PurchaseUnits[0].AmountWithBreakdown.AmountBreakdown.TaxTotal = new Money
-                {
-                    CurrencyCode = currencyCodeType,
-                    Value = formatAmount(taxTotal)
-                };
-            }
 
             var request = new OrdersCreateRequest();
             request.Prefer(REQUEST_RETURN_TYPE);
@@ -299,21 +291,17 @@ namespace Hotcakes.PaypalWebServices
                                 {
                                     CurrencyCode = currencyCodeType,
                                     Value = formatAmount(itemsTotal)
+                                },
+                                TaxTotal = new Money
+                                {
+                                    CurrencyCode = currencyCodeType,
+                                    Value = formatAmount(taxTotal)
                                 }
                             }
                         }
                     }
                 }
             };
-
-            if (!string.IsNullOrEmpty(taxTotal))
-            {
-                order.PurchaseUnits[0].AmountWithBreakdown.AmountBreakdown.TaxTotal = new Money
-                {
-                    CurrencyCode = currencyCodeType,
-                    Value = formatAmount(taxTotal)
-                };
-            }
 
             // Call API with your client and get a response for your call
             var request = new OrdersCreateRequest();

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Default.aspx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Default.aspx.cs
@@ -111,9 +111,9 @@ namespace Hotcakes.Modules.Core.Admin.Catalog
             {
                 var conf = objConfiguration as ExportConfiguration;
 
+                Factory.HttpContext = conf.HttpContext;
                 HccRequestContext.Current = conf.HccRequestContext;
                 DnnGlobal.SetPortalSettings(conf.DnnPortalSettings);
-                Factory.HttpContext = conf.HttpContext;
                 CultureSwitch.SetCulture(HccApp.CurrentStore, conf.DnnPortalSettings);
 
                 var products = HccApp.CatalogServices.Products.FindByCriteria(conf.Criteria, 1, int.MaxValue,

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Products_Import.aspx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Catalog/Products_Import.aspx.cs
@@ -124,9 +124,10 @@ namespace Hotcakes.Modules.Core.Admin.Catalog
 		{
 			var conf = objConfiguration as ImportConfiguration;
 
-			HccRequestContext.Current = conf.HccRequestContext;
-			DnnGlobal.SetPortalSettings(conf.DnnPortalSettings);
-			Factory.HttpContext = conf.HttpContext;
+            Factory.HttpContext = conf.HttpContext;
+            HccRequestContext.Current = conf.HccRequestContext;
+
+            DnnGlobal.SetPortalSettings(conf.DnnPortalSettings);
 			CultureSwitch.SetCulture(HccApp.CurrentStore, conf.DnnPortalSettings);
 
 			var manager = new SessionManager(conf.Session);

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Parts/PaymentMethods/PaypalExpress/App_LocalResources/Edit.ascx.resx
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Parts/PaymentMethods/PaypalExpress/App_LocalResources/Edit.ascx.resx
@@ -117,7 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  
   <data name="APIClientId.Text" xml:space="preserve">
     <value>API Client Id</value>
   </data>
@@ -168,5 +167,8 @@
   </data>
   <data name="chkRequirePayPalAccount.Text" xml:space="preserve">
     <value>Require PayPal Account</value>
+  </data>
+  <data name="chkSkipTotalBreakdown.Text" xml:space="preserve">
+    <value>Skip Breakdown of Totals (Only Send Order Total)</value>
   </data>
 </root>

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Parts/PaymentMethods/PaypalExpress/Edit.ascx
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Parts/PaymentMethods/PaypalExpress/Edit.ascx
@@ -34,6 +34,9 @@
         <div class="hcFormItem">
             <asp:CheckBox ID="chkRequirePayPalAccount" runat="server" resourcekey="chkRequirePayPalAccount" />
         </div>
+        <div class="hcFormItem">
+            <asp:CheckBox ID="chkSkipTotalBreakdown" runat="server" resourcekey="chkSkipTotalBreakdown" />
+        </div>
     </div>
 </div>
 <div class="hcColumnRight" style="width: 50%;">

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Parts/PaymentMethods/PaypalExpress/Edit.ascx.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Parts/PaymentMethods/PaypalExpress/Edit.ascx.cs
@@ -54,6 +54,7 @@ namespace Hotcakes.Modules.Core.Modules.PaymentMethods.PaypalExpress
 
             chkUnconfirmedAddress.Checked = HccApp.CurrentStore.Settings.PayPal.AllowUnconfirmedAddresses;
             chkRequirePayPalAccount.Checked = HccApp.CurrentStore.Settings.PayPal.RequirePayPalAccount;
+            chkSkipTotalBreakdown.Checked = HccApp.CurrentStore.Settings.PayPal.NoOrderTotalBreakdown;
             ddlCurrency.SelectedValue = HccApp.CurrentStore.Settings.PayPal.Currency;
         }
 
@@ -68,6 +69,7 @@ namespace Hotcakes.Modules.Core.Modules.PaymentMethods.PaypalExpress
             HccApp.CurrentStore.Settings.PayPal.ExpressAuthorizeOnly = authorizeOnly;
             HccApp.CurrentStore.Settings.PayPal.AllowUnconfirmedAddresses = chkUnconfirmedAddress.Checked;
             HccApp.CurrentStore.Settings.PayPal.RequirePayPalAccount = chkRequirePayPalAccount.Checked;
+            HccApp.CurrentStore.Settings.PayPal.NoOrderTotalBreakdown = chkSkipTotalBreakdown.Checked;
             HccApp.CurrentStore.Settings.PayPal.Currency = ddlCurrency.SelectedValue;
 
             HccApp.AccountServices.Stores.Update(HccApp.CurrentStore);

--- a/Website/DesktopModules/Hotcakes/Core/Admin/Parts/PaymentMethods/PaypalExpress/Edit.ascx.designer.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Admin/Parts/PaymentMethods/PaypalExpress/Edit.ascx.designer.cs
@@ -69,6 +69,15 @@ namespace Hotcakes.Modules.Core.Modules.PaymentMethods.PaypalExpress
         protected global::System.Web.UI.WebControls.CheckBox chkRequirePayPalAccount;
 
         /// <summary>
+        /// chkSkipTotalBreakdown control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CheckBox chkSkipTotalBreakdown;
+
+        /// <summary>
         /// txtSecret control.
         /// </summary>
         /// <remarks>

--- a/Website/DesktopModules/Hotcakes/Core/Controllers/PayPalExpressCheckoutController.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Controllers/PayPalExpressCheckoutController.cs
@@ -179,7 +179,7 @@ namespace Hotcakes.Modules.Core.Controllers
                     model.CurrentOrder.ShippingAddress.Line1 = purchaseUnits[0].ShippingDetail.AddressPortable.AddressLine1 ?? string.Empty;
                     model.CurrentOrder.ShippingAddress.Line2 = purchaseUnits[0].ShippingDetail.AddressPortable.AddressLine2 ?? string.Empty;
                     model.CurrentOrder.ShippingAddress.CountryBvin = country.Bvin ?? string.Empty;
-                    model.CurrentOrder.ShippingAddress.City = purchaseUnits[0].ShippingDetail.AddressPortable.AdminArea1 ?? string.Empty;
+                    model.CurrentOrder.ShippingAddress.City = purchaseUnits[0].ShippingDetail.AddressPortable.AdminArea2 ?? string.Empty;
                     //model.CurrentOrder.ShippingAddress.RegionBvin = payerInfo.Address.StateOrProvince ?? string.Empty;
                     model.CurrentOrder.ShippingAddress.PostalCode = purchaseUnits[0].ShippingDetail.AddressPortable.PostalCode ?? string.Empty;
                     //model.CurrentOrder.ShippingAddress.Phone = purchaseUnits[0].ShippingDetail.AddressPortable.AddressLine3 ?? string.Empty;
@@ -188,9 +188,9 @@ namespace Hotcakes.Modules.Core.Controllers
                     model.CurrentOrder.BillingAddress.FirstName = payerInfo.Name.GivenName;
                     model.CurrentOrder.BillingAddress.LastName = payerInfo.Name.Surname;
                     model.CurrentOrder.BillingAddress.Line1 = payerInfo.AddressPortable.AddressLine1 ?? string.Empty;
-                    model.CurrentOrder.BillingAddress.Line2 = payerInfo.AddressPortable.AdminArea2 ?? string.Empty;
+                    model.CurrentOrder.BillingAddress.Line2 = payerInfo.AddressPortable.AddressLine2 ?? string.Empty;
                     model.CurrentOrder.BillingAddress.CountryBvin = country.Bvin ?? string.Empty;
-                    model.CurrentOrder.BillingAddress.City = payerInfo.AddressPortable.AdminArea1 ?? string.Empty;
+                    model.CurrentOrder.BillingAddress.City = payerInfo.AddressPortable.AdminArea2 ?? string.Empty;
                     model.CurrentOrder.BillingAddress.PostalCode = payerInfo.AddressPortable.PostalCode ?? string.Empty;
 
                     ViewBag.AddressStatus = Localization.GetString("Confirmed");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #553 

## Description
After having a successful checkout with PayPalExpress and having shipping items the City in the Hotcakes order is overwritten with the State from the PayPal form.

This only happens on Shipping Orders.
## How Has This Been Tested?
This has been tested on my development environment. I am also deploying this to my production environment tomorrow to monitor and test the fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.